### PR TITLE
EE-3856: Added `DiacriticNameNormalizer` to transform to basic latin

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/SpringConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/SpringConfiguration.java
@@ -19,6 +19,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import uk.gov.digital.ho.pttg.api.RequestData;
+import uk.gov.digital.ho.pttg.application.util.CompositeNameNormalizer;
+import uk.gov.digital.ho.pttg.application.util.DiacriticNameNormalizer;
 import uk.gov.digital.ho.pttg.application.util.MaxLengthNameNormalizer;
 import uk.gov.digital.ho.pttg.application.util.NameNormalizer;
 
@@ -125,7 +127,11 @@ public class SpringConfiguration extends WebMvcConfigurerAdapter {
 
     @Bean
     public NameNormalizer nameNormalizer() {
-        return new MaxLengthNameNormalizer(hmrcNameMaxLength);
+        NameNormalizer[] nameNormalizers = {
+                new MaxLengthNameNormalizer(hmrcNameMaxLength),
+                new DiacriticNameNormalizer()
+        };
+        return new CompositeNameNormalizer(nameNormalizers);
     }
 }
 

--- a/src/main/java/uk/gov/digital/ho/pttg/application/util/CompositeNameNormalizer.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/util/CompositeNameNormalizer.java
@@ -1,0 +1,24 @@
+package uk.gov.digital.ho.pttg.application.util;
+
+import uk.gov.digital.ho.pttg.dto.Individual;
+
+import static java.util.Objects.requireNonNull;
+
+public class CompositeNameNormalizer implements NameNormalizer {
+    private final NameNormalizer[] nameNormalizers;
+
+    public CompositeNameNormalizer(NameNormalizer[] nameNormalizers) {
+        this.nameNormalizers = requireNonNull(nameNormalizers);
+    }
+
+    @Override
+    public Individual normalizeNames(Individual individual) {
+
+        Individual normalizedIndividual = individual;
+        for (NameNormalizer nameNormalizer : nameNormalizers) {
+            normalizedIndividual = nameNormalizer.normalizeNames(normalizedIndividual);
+        }
+
+        return normalizedIndividual;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/application/util/DiacriticNameNormalizer.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/util/DiacriticNameNormalizer.java
@@ -1,0 +1,40 @@
+package uk.gov.digital.ho.pttg.application.util;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.digital.ho.pttg.dto.Individual;
+
+import static java.lang.Character.UnicodeBlock.BASIC_LATIN;
+
+public class DiacriticNameNormalizer implements NameNormalizer {
+    @Override
+    public Individual normalizeNames(Individual individual) {
+        String normalizedFirstName = toBasicLatin(individual.getFirstName());
+        String normalizedLastName = toBasicLatin(individual.getLastName());
+
+        return new Individual(normalizedFirstName, normalizedLastName, individual.getNino(), individual.getDateOfBirth());
+    }
+
+    private String toBasicLatin(String name) {
+        String nameWithoutAccents = StringUtils.stripAccents(name);
+        return permitOnlyBasicLatinCharacters(nameWithoutAccents);
+    }
+
+    private String permitOnlyBasicLatinCharacters(String str) {
+        if (str == null) {
+            return null;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        for (char c : str.toCharArray()) {
+            if (isAllowedCharacter(c)) {
+                stringBuilder.append(c);
+            }
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private boolean isAllowedCharacter(char c) {
+        return Character.UnicodeBlock.of(c).equals(BASIC_LATIN);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/util/CompositeNameNormalizerTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/util/CompositeNameNormalizerTest.java
@@ -1,0 +1,87 @@
+package uk.gov.digital.ho.pttg.application.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.digital.ho.pttg.dto.Individual;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompositeNameNormalizerTest {
+    @Mock
+    private Individual mockInputIndividual;
+
+    @Mock
+    private Individual mockOutputIndividual;
+
+    private CompositeNameNormalizer compositeNameNormalizer;
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerWhenArrayIsNull() {
+        new CompositeNameNormalizer(null);
+    }
+
+    @Test
+    public void shouldReturnInputtedIndividualWhenNoNameNormalizers() {
+        // given
+        NameNormalizer[] nameNormalizers = {};
+        compositeNameNormalizer = new CompositeNameNormalizer(nameNormalizers);
+
+        // when
+        Individual actualIndividual = compositeNameNormalizer.normalizeNames(mockInputIndividual);
+
+        // then
+        assertThat(actualIndividual).isEqualTo(mockInputIndividual);
+        verifyNoMoreInteractions(mockInputIndividual);
+    }
+
+    @Test
+    public void shouldCallSingleNameNormalizer() {
+        // given
+
+        NameNormalizer mockNameNormalizerOne = setupNameNormalizerMock();
+        NameNormalizer[] nameNormalizers = {mockNameNormalizerOne};
+
+        compositeNameNormalizer = new CompositeNameNormalizer(nameNormalizers);
+
+        // when
+        Individual actualIndividual = compositeNameNormalizer.normalizeNames(mockInputIndividual);
+
+        // then
+        verify(mockNameNormalizerOne).normalizeNames(mockInputIndividual);
+
+        assertThat(actualIndividual).isEqualTo(mockOutputIndividual);
+        verifyNoMoreInteractions(mockOutputIndividual);
+    }
+
+    @Test
+    public void shouldCallMultipleNameNormalizers() {
+        // given
+
+        NameNormalizer mockNameNormalizerOne = setupNameNormalizerMock();
+        NameNormalizer mockNameNormalizerTwo = setupNameNormalizerMock();
+        NameNormalizer[] nameNormalizers = {mockNameNormalizerOne, mockNameNormalizerTwo};
+
+        compositeNameNormalizer = new CompositeNameNormalizer(nameNormalizers);
+
+        // when
+        Individual actualIndividual = compositeNameNormalizer.normalizeNames(mockInputIndividual);
+
+        // then
+        verify(mockNameNormalizerOne).normalizeNames(mockInputIndividual);
+        verify(mockNameNormalizerTwo).normalizeNames(mockOutputIndividual);
+
+        assertThat(actualIndividual).isEqualTo(mockOutputIndividual);
+        verifyNoMoreInteractions(mockOutputIndividual);
+    }
+
+    private NameNormalizer setupNameNormalizerMock() {
+        NameNormalizer mock = mock(NameNormalizer.class);
+        when(mock.normalizeNames(any())).thenReturn(mockOutputIndividual);
+        return mock;
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/util/DiacriticNameNormalizerTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/util/DiacriticNameNormalizerTest.java
@@ -1,0 +1,110 @@
+package uk.gov.digital.ho.pttg.application.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.digital.ho.pttg.dto.Individual;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DiacriticNameNormalizerTest {
+    private static final String TEST_NINO = "Test Nino";
+    private static final LocalDate TEST_DOB = LocalDate.of(2000, Month.DECEMBER, 25);
+
+    private DiacriticNameNormalizer accentNameNormalizer;
+
+    @Before
+    public void setUp() {
+        accentNameNormalizer = new DiacriticNameNormalizer();
+    }
+
+    @Test
+    public void shouldReturnNamesWithAccentsRemoved() {
+        // given
+        String firstName = "Tĥïŝ ĩš";
+        String lastName = "â fůňķŷ Šťŕĭńġ";
+        Individual individual = new Individual(firstName, lastName, TEST_NINO, TEST_DOB);
+
+        // when
+        Individual normalizedIndividual = accentNameNormalizer.normalizeNames(individual);
+
+        // then
+        assertThat(normalizedIndividual.getFirstName()).isEqualTo("This is");
+        assertThat(normalizedIndividual.getLastName()).isEqualTo("a funky String");
+
+        assertThat(normalizedIndividual.getNino()).isEqualTo(TEST_NINO);
+        assertThat(normalizedIndividual.getDateOfBirth()).isEqualTo(TEST_DOB);
+    }
+
+    @Test
+    public void shouldLeaveLatinBasicCharactersAsTheyWereInputted() {
+        // given
+        String firstName = "Querty";
+        String lastName = "Smith";
+        Individual individual = new Individual(firstName, lastName, TEST_NINO, TEST_DOB);
+
+        // when
+        Individual normalizedIndividual = accentNameNormalizer.normalizeNames(individual);
+
+        // then
+        assertThat(normalizedIndividual.getFirstName()).isEqualTo("Querty");
+        assertThat(normalizedIndividual.getLastName()).isEqualTo("Smith");
+
+        assertThat(normalizedIndividual.getNino()).isEqualTo(TEST_NINO);
+        assertThat(normalizedIndividual.getDateOfBirth()).isEqualTo(TEST_DOB);
+    }
+
+    @Test
+    public void shouldRemoveAllNonBasicLatinCharactersThatCannotBeNormalized() {
+        // given
+        String firstName = "ØJohnŁ";
+        String lastName = "ƝSmithÆ";
+        Individual individual = new Individual(firstName, lastName, TEST_NINO, TEST_DOB);
+
+        // when
+        Individual normalizedIndividual = accentNameNormalizer.normalizeNames(individual);
+
+        // then
+        assertThat(normalizedIndividual.getFirstName()).isEqualTo("John");
+        assertThat(normalizedIndividual.getLastName()).isEqualTo("Smith");
+
+        assertThat(normalizedIndividual.getNino()).isEqualTo(TEST_NINO);
+        assertThat(normalizedIndividual.getDateOfBirth()).isEqualTo(TEST_DOB);
+    }
+
+    @Test
+    public void shouldReturnEmptyNamesWhenNamesAreEmpty() {
+        // given
+        String firstName = "";
+        String lastName = "";
+        Individual individual = new Individual(firstName, lastName, TEST_NINO, TEST_DOB);
+
+        // when
+        Individual normalizedIndividual = accentNameNormalizer.normalizeNames(individual);
+
+        // then
+        assertThat(normalizedIndividual.getFirstName()).isEmpty();
+        assertThat(normalizedIndividual.getLastName()).isEmpty();
+
+        assertThat(normalizedIndividual.getNino()).isEqualTo(TEST_NINO);
+        assertThat(normalizedIndividual.getDateOfBirth()).isEqualTo(TEST_DOB);
+    }
+
+    @Test
+    public void shouldReturnNullNamesWhenNamesAreNull() {
+        // given
+        Individual individual = new Individual(null, null, TEST_NINO, TEST_DOB);
+
+        // when
+        Individual normalizedIndividual = accentNameNormalizer.normalizeNames(individual);
+
+        // then
+        assertThat(normalizedIndividual.getFirstName()).isNull();
+        assertThat(normalizedIndividual.getLastName()).isNull();
+
+        assertThat(normalizedIndividual.getNino()).isEqualTo(TEST_NINO);
+        assertThat(normalizedIndividual.getDateOfBirth()).isEqualTo(TEST_DOB);
+    }
+}


### PR DESCRIPTION
This ticket is not complete yet but is being merged in now ahead of live proving.

Still left is:
- What to do about letters that cannot be converted (diacritic overlays and subscript curls).
- Add support for multiple alphabets beyond basic latin.