### PR TITLE
EE-7270 Enforce TLS 1.2 for all HMRC API calls

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/SpringConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/SpringConfiguration.java
@@ -48,12 +48,9 @@ public class SpringConfiguration implements WebMvcConfigurer {
     private final Integer proxyPort;
 
     private final TimeoutProperties timeoutProperties;
+    private final RetryProperties retryProperties;
 
     private final int hmrcNameMaxLength;
-
-    private final int hmrcUnauthorizedRetryAttempts;
-    private final int hmrcApiFailureRetryAttempts;
-    private final int retryDelay;
     private final String[] supportedSslProtocols;
 
     public SpringConfiguration(ObjectMapper objectMapper,
@@ -71,10 +68,8 @@ public class SpringConfiguration implements WebMvcConfigurer {
         this.proxyHost = proxyHost;
         this.proxyPort = proxyPort;
         this.hmrcNameMaxLength = hmrcNameMaxLength;
-        this.hmrcUnauthorizedRetryAttempts = retryProperties.getUnauthorizedAttempts();
-        this.hmrcApiFailureRetryAttempts = retryProperties.getAttempts();
-        this.retryDelay = retryProperties.getDelay();
         this.timeoutProperties = timeoutProperties;
+        this.retryProperties = retryProperties;
 
         initialiseObjectMapper(objectMapper);
         this.supportedSslProtocols = supportedSslProtocols.toArray(new String[]{});
@@ -200,15 +195,15 @@ public class SpringConfiguration implements WebMvcConfigurer {
 
     @Bean
     public RetryTemplate reauthorisingRetryTemplate() {
-        return new RetryTemplateBuilder(hmrcUnauthorizedRetryAttempts)
+        return new RetryTemplateBuilder(retryProperties.getUnauthorizedAttempts())
                 .retryHmrcUnauthorisedException()
                 .build();
     }
 
     @Bean
     public RetryTemplate apiFailureRetryTemplate() {
-        return new RetryTemplateBuilder(hmrcApiFailureRetryAttempts)
-                .withBackOffPeriod(retryDelay)
+        return new RetryTemplateBuilder(retryProperties.getAttempts())
+                .withBackOffPeriod(retryProperties.getDelay())
                 .retryHttpServerErrors()
                 .build();
     }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/retry/RetryProperties.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/retry/RetryProperties.java
@@ -1,0 +1,35 @@
+package uk.gov.digital.ho.pttg.application.retry;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "hmrc")
+@Setter
+public class RetryProperties {
+
+    private Retry retry;
+
+    @Getter
+    @Setter
+    public static class Retry {
+        private int attempts;
+        private int delay;
+        private int unauthorizedAttempts;
+    }
+
+    public int getAttempts() {
+        return retry.getAttempts();
+    }
+
+    public int getDelay() {
+        return retry.getDelay();
+    }
+
+    public int getUnauthorizedAttempts() {
+        return retry.getUnauthorizedAttempts();
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,7 +39,10 @@ hmrc.endpoint=${base.hmrc.url}
 
 hmrc.retry.attempts=3
 hmrc.retry.delay=1000
-hmrc.retry.unauthorized.attempts=2
+hmrc.retry.unauthorized-attempts=2
+
+hmrc.ssl.supportedProtocols=TLSv1.2
+
 #
 # HMRC access code endpoints
 #

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceIntegrationTest.java
@@ -50,7 +50,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
         classes = ServiceRunner.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {
-        "hmrc.retry.unauthorized.attempts=2",
+        "hmrc.retry.unauthorized-attempts=2",
         "hmrc.access.service.retry.attempts=3"
 })
 public class HmrcResourceIntegrationTest {

--- a/src/test/java/uk/gov/digital/ho/pttg/application/SpringConfigurationTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/SpringConfigurationTest.java
@@ -14,6 +14,8 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -133,7 +135,7 @@ public class SpringConfigurationTest {
     }
 
     @Test
-    public void shouldEvictStaleHttpClientConnections() {
+    public void shouldEvictStaleHttpClientConnections() throws KeyManagementException, NoSuchAlgorithmException {
         SpringConfiguration springConfig = new SpringConfiguration(new ObjectMapper(), false, null, null, null, 35, 1, 1, 1, mockTimeoutProperties);
 
         HttpClientBuilder builder = springConfig.createHttpClientBuilder();

--- a/src/test/java/uk/gov/digital/ho/pttg/application/SpringConfigurationTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/SpringConfigurationTest.java
@@ -15,8 +15,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.pttg.application.retry.RetryProperties;
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +28,6 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_INFERRED")
 public class SpringConfigurationTest {
-
 
     @Mock
     private RestTemplateBuilder mockRestTemplateBuilder;
@@ -62,7 +59,7 @@ public class SpringConfigurationTest {
         timeoutProperties.setHmrcAccessCode(new TimeoutProperties.HmrcAccessCode());
         timeoutProperties.setHmrcApi(new TimeoutProperties.HmrcApi());
 
-        anyRetryProperties= new RetryProperties();
+        anyRetryProperties = new RetryProperties();
         anyRetryProperties.setRetry(new RetryProperties.Retry());
     }
 
@@ -144,7 +141,7 @@ public class SpringConfigurationTest {
     }
 
     @Test
-    public void shouldEvictStaleHttpClientConnections() throws KeyManagementException, NoSuchAlgorithmException {
+    public void shouldEvictStaleHttpClientConnections() {
         SpringConfiguration springConfig = new SpringConfiguration(new ObjectMapper(), false, null, null, null, 35, anySSLProtocols, anyRetryProperties, mockTimeoutProperties);
 
         HttpClientBuilder builder = springConfig.createHttpClientBuilder();


### PR DESCRIPTION
Made it so that the RestTemplate used to communicate with the HMRC API will only use TLSv1.2. 

Because implementing this added another parameter to the SpringConfiguration, pushing it over the static code-check's permitted maximum, I have also refactored this class. There is now a RetryProperties class which wraps the three properties related to HMRC API call retries.

There is no automated test associated with this change because it was not feasible. The code inside the Java/Apache libraries that this code affects is far to complicated to realistically inspect its state through reflection. And developing some sort of mock server that we control the TLS version for in order to test against is a lot of work for a comparatively small gain.