### PR TITLE
EE-8204 Adding BDD for hyphenated and apostrophe names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ repositories {
     testCompile group: 'org.spockframework', name: 'spock-core', version: '1.1-groovy-2.4-rc-2'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.5.2'
-    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.6.0'
+    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.18.0'
     testCompile group: 'com.jayway.jsonpath', name: 'json-path'
     testCompile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
     testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.5'

--- a/src/test/groovy/acceptance/steps/NameMatchingSteps.groovy
+++ b/src/test/groovy/acceptance/steps/NameMatchingSteps.groovy
@@ -109,9 +109,31 @@ class NameMatchingSteps {
         for (individual in individuals) {
             def expectedJson = getIndividualMatchRequestExpectedJson(individual)
 
+            // Match full json response
             HMRC_MOCK_SERVICE.stubFor(post(urlEqualTo(INDIVIDUAL_MATCHING_ENDPOINT))
                     .atPriority(1)
                     .withRequestBody(equalToJson(expectedJson, IGNORE_JSON_ARRAY_ORDER, IGNORE_EXTRA_ELEMENTS))
+                    .willReturn(aResponse().withBody(buildMatchResponse()).withStatus(HttpStatus.OK.value())
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)))
+
+            int nameLength = individual.getFirstName().length()
+            int surnameLength = individual.getLastName().length()
+            int nameIndex = 3
+            int surnameIndex = 3
+            if (nameLength < 3) {
+                nameIndex = nameLength
+            }
+            if (surnameLength < 3) {
+                surnameIndex = surnameLength
+            }
+
+            // Match json with initials of name and surname only
+            HMRC_MOCK_SERVICE.stubFor(post(urlEqualTo(INDIVIDUAL_MATCHING_ENDPOINT))
+                    .atPriority(1)
+                    .withRequestBody(matchingJsonPath("\$.firstName", matching(individual.getFirstName().substring(0, nameIndex)  + ".*")))
+                    .withRequestBody(matchingJsonPath("\$.lastName", matching(individual.getLastName().substring(0, surnameIndex) + ".*")))
+                    .withRequestBody(matchingJsonPath("\$.nino"))
+                    .withRequestBody(matchingJsonPath("\$.dateOfBirth"))
                     .willReturn(aResponse().withBody(buildMatchResponse()).withStatus(HttpStatus.OK.value())
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)))
         }

--- a/src/test/groovy/acceptance/steps/NameMatchingSteps.groovy
+++ b/src/test/groovy/acceptance/steps/NameMatchingSteps.groovy
@@ -116,16 +116,9 @@ class NameMatchingSteps {
                     .willReturn(aResponse().withBody(buildMatchResponse()).withStatus(HttpStatus.OK.value())
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)))
 
-            int nameLength = individual.getFirstName().length()
-            int surnameLength = individual.getLastName().length()
-            int nameIndex = 3
-            int surnameIndex = 3
-            if (nameLength < 3) {
-                nameIndex = nameLength
-            }
-            if (surnameLength < 3) {
-                surnameIndex = surnameLength
-            }
+            // Get at least the first letter of the firstname and at least the first three letters of the lastname
+            int nameIndex = Math.min(1, (int) individual.getFirstName().length())
+            int surnameIndex = Math.min(3, (int) individual.getLastName().length())
 
             // Match json with initials of name and surname only
             HMRC_MOCK_SERVICE.stubFor(post(urlEqualTo(INDIVIDUAL_MATCHING_ENDPOINT))

--- a/src/test/resources/specs/name-matching/Name_7Strings_HMRC.feature
+++ b/src/test/resources/specs/name-matching/Name_7Strings_HMRC.feature
@@ -133,12 +133,12 @@ Feature: Name matching with 7 name strings
       | Date of Birth | 1987-12-10                        |
       | nino          | SE 123456 B                       |
     Then a Matched response will be returned from the service
-    And HMRC was called 54 times
+    And HMRC was called 6 times
 
   @name_matching
   Scenario: Applicant with a hyphenated first name is matched in HMRC on the hyphenated version of the name
     Given HMRC has the following individual records
-      | First name    | Last name | Date of Birth | nino        |
+      | First name     | Last name | Date of Birth | nino        |
       | Bob-Chicharito | Higuain   | 1987-12-10    | SE 123456 B |
     When the applicant submits the following data to the RPS service
       | First name    | Ali Bob-Chicharito Danilo Estoban |
@@ -151,13 +151,13 @@ Feature: Name matching with 7 name strings
   @name_matching
   Scenario: Applicant with a hyphenated last name is matched in HMRC on the hyphenated version of the name
     Given HMRC has the following individual records
-      | First name    | Last name | Date of Birth | nino        |
-      | Bob           | El-Mohtar   | 1987-12-10    | SE 123456 B |
+      | First name | Last name | Date of Birth | nino        |
+      | Bob        | El-Mohtar | 1987-12-10    | SE 123456 B |
     When the applicant submits the following data to the RPS service
-      | First name    | Bob |
-      | Last name     | El-Mohtar          |
-      | Date of Birth | 1987-12-10                        |
-      | nino          | SE 123456 B                       |
+      | First name    | Bob         |
+      | Last name     | El-Mohtar   |
+      | Date of Birth | 1987-12-10  |
+      | nino          | SE 123456 B |
     Then a Matched response will be returned from the service
     And HMRC was called 1 times
 

--- a/src/test/resources/specs/name-matching/Name_With_Special_Characters.feature
+++ b/src/test/resources/specs/name-matching/Name_With_Special_Characters.feature
@@ -3,7 +3,6 @@
 @story=Names_With_Special_Characters
 @jira=EE-8204
 
-
 Feature: Accept Hyphens and Apostrophes as part of the name matching
 
 

--- a/src/test/resources/specs/name-matching/Name_With_Special_Characters.feature
+++ b/src/test/resources/specs/name-matching/Name_With_Special_Characters.feature
@@ -1,0 +1,132 @@
+@Sprint=16.2
+@epic=EE-3855
+@story=Names_With_Special_Characters
+@jira=EE-8204
+
+
+Feature: Accept Hyphens and Apostrophes as part of the name matching
+
+
+    @name_matching
+    Scenario: Applicant with a hyphenated name
+        Given HMRC has the following individual records
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb-Ccc    | 1987-12-10    | SE 123456 B |
+        When the applicant submits the following data to the RPS service
+            | First name    | Aaa         |
+            | Last name     | Bb-Ccc      |
+            | Date of Birth | 1987-12-10  |
+            | nino          | SE 123456 B |
+        Then the footprint will try the following combination of names in order
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb-Ccc    | 1987-12-10    | SE 123456 B |
+        And a Matched response will be returned from the service
+        And HMRC was called 1 times
+
+
+    @name_matching
+    Scenario: Applicant with a hyphenated name and surname
+        Given HMRC has the following individual records
+            | First name | Last name | Date of Birth | nino        |
+            | Aa-Bbb     | Cc-Ddd    | 1987-12-10    | SE 123456 B |
+        When the applicant submits the following data to the RPS service
+            | First name    | Cc-Ddd      |
+            | Last name     | Aa-Bbb      |
+            | Date of Birth | 1987-12-10  |
+            | nino          | SE 123456 B |
+        Then the footprint will try the following combination of names in order
+            | First name | Last name | Date of Birth | nino        |
+            | Cc-Ddd     | Aa-Bbb    | 1987-12-10    | SE 123456 B |
+            | Aa-Bbb     | Cc-Ddd    | 1987-12-10    | SE 123456 B |
+        And a Matched response will be returned from the service
+        And HMRC was called 2 times
+
+
+    @name_matching
+    Scenario: Applicant with a hyphenated surname is matched when more than the original names are sent via the API
+        Given HMRC has the following individual records
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb-       | 1987-12-10    | SE 123456 B |
+        When the applicant submits the following data to the RPS service
+            | First name    | Aaa         |
+            | Last name     | Bb- Ccc     |
+            | Date of Birth | 1987-12-10  |
+            | nino          | SE 123456 B |
+        Then the footprint will try the following combination of names in order
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb- Ccc   | 1987-12-10    | SE 123456 B |
+        And a Matched response will be returned from the service
+        And HMRC was called 1 times
+
+
+    @name_matching
+    Scenario: Applicant enters hyphen when name does not contain a hyphen
+        Given HMRC has the following individual records
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb Ccc    | 1987-12-10    | SE 123456 B |
+        When the applicant submits the following data to the RPS service
+            | First name    | Aaa         |
+            | Last name     | Bb-Ccc      |
+            | Date of Birth | 1987-12-10  |
+            | nino          | SE 123456 B |
+        Then the footprint will try the following combination of names in order
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb-Ccc    | 1987-12-10    | SE 123456 B |
+            | Bb-Ccc     | Aaa       | 1987-12-10    | SE 123456 B |
+            | Aaa        | Bb Ccc    | 1987-12-10    | SE 123456 B |
+        And a Matched response will be returned from the service
+        And HMRC was called 3 times
+
+
+    @name_matching
+    Scenario: Applicant enters hyphen when name does not contain a hyphen
+        Given HMRC has the following individual records
+            | First name | Last name | Date of Birth | nino        |
+            | Bb         | Aaa       | 1987-12-10    | SE 123456 B |
+        When the applicant submits the following data to the RPS service
+            | First name    | Aaa         |
+            | Last name     | Bb-Ccc      |
+            | Date of Birth | 1987-12-10  |
+            | nino          | SE 123456 B |
+        Then the footprint will try the following combination of names in order
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb-Ccc    | 1987-12-10    | SE 123456 B |
+            | Bb-Ccc     | Aaa       | 1987-12-10    | SE 123456 B |
+        And a Matched response will be returned from the service
+        And HMRC was called 2 times
+
+
+    @name_matching
+    Scenario: Applicant with a name containing an apostrophe
+        Given HMRC has the following individual records
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb'Ccc    | 1987-12-10    | SE 123456 B |
+        When the applicant submits the following data to the RPS service
+            | First name    | Aaa         |
+            | Last name     | Bb'Ccc      |
+            | Date of Birth | 1987-12-10  |
+            | nino          | SE 123456 B |
+        Then the footprint will try the following combination of names in order
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb'Ccc    | 1987-12-10    | SE 123456 B |
+        And a Matched response will be returned from the service
+        And HMRC was called 1 times
+
+
+    @name_matching
+    Scenario: Applicant enters apostrophe when name does not contain an apostrophe
+        Given HMRC has the following individual records
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb Ccc    | 1987-12-10    | SE 123456 B |
+        When the applicant submits the following data to the RPS service
+            | First name    | Aaa         |
+            | Last name     | Bb'Ccc      |
+            | Date of Birth | 1987-12-10  |
+            | nino          | SE 123456 B |
+        Then the footprint will try the following combination of names in order
+            | First name | Last name | Date of Birth | nino        |
+            | Aaa        | Bb'Ccc    | 1987-12-10    | SE 123456 B |
+            | Bb'Ccc     | Aaa       | 1987-12-10    | SE 123456 B |
+            | Aaa        | Bb Ccc    | 1987-12-10    | SE 123456 B |
+        And a Matched response will be returned from the service
+        And HMRC was called 3 times


### PR DESCRIPTION
Updating wiremock version to be able to use newer mock functionalities. Updated mock to match on name/surname initials, in addition to full json object. Added BDD for hyphenated/apostrophe names