### PR TITLE
Ee 9538 name matching dedupe

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGenerator.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGenerator.java
@@ -10,6 +10,7 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.digital.ho.pttg.application.namematching.NameMatchingCandidatesGeneratorFunctions.deduplicate;
 
 public class NameMatchingCandidatesGenerator {
     private static final String NAME_SPLITTERS = "-'";
@@ -28,7 +29,7 @@ public class NameMatchingCandidatesGenerator {
             candidates.addAll(generateCandidatesWithSplitters(firstName, lastName));
         }
 
-        return Collections.unmodifiableList(candidates);
+        return Collections.unmodifiableList(deduplicate(candidates));
     }
 
     private static boolean namesContainSplitters(String firstName, String lastName) {

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorFunctions.java
@@ -1,0 +1,17 @@
+package uk.gov.digital.ho.pttg.application.namematching;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class NameMatchingCandidatesGeneratorFunctions {
+
+    static List<PersonName> deduplicate(List<PersonName> candidateNames) {
+        Set<PersonName> seenHmrcEquivalentNames = new HashSet<>();
+        return candidateNames.stream()
+                .filter(name -> seenHmrcEquivalentNames.add(name.hmrcNameMatchingEquivalent()))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/PersonName.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/PersonName.java
@@ -14,4 +14,14 @@ import lombok.experimental.Accessors;
 public class PersonName {
     private String firstName;
     private String lastName;
+
+    PersonName hmrcNameMatchingEquivalent() {
+        String firstInitial = firstNLetters(1, this.firstName);
+        String surnameFirstThreeLetters = firstNLetters(3, this.lastName);
+        return new PersonName(firstInitial, surnameFirstThreeLetters);
+    }
+
+    private String firstNLetters(int n, String string) {
+        return string.substring(0, Math.min(string.length(), n));
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/PersonName.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/PersonName.java
@@ -18,28 +18,22 @@ public class PersonName {
 
     PersonName hmrcNameMatchingEquivalent() {
         String firstInitial = firstNLetters(1, this.firstName);
-        String surnameFirstThreeSignificantCharacters = firstNLetters(3, this.lastName);
-        return new PersonName(firstInitial, surnameFirstThreeSignificantCharacters);
+        String surnameStart = firstNLetters(3, this.lastName);
+        return new PersonName(firstInitial, surnameStart);
     }
 
     private String firstNLetters(int n, String name) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < name.length(); i++) {
-            stringBuilder.append(name, i, i + 1);
-            if (countSignificantCharacters(stringBuilder.toString()) >= n) {
+        int endIndex = 0;
+        int significantCharacters = 0;
+        for (char letter : name.toCharArray()) {
+            endIndex++;
+            if (!StringUtils.isWhitespace(String.valueOf(letter))) {
+                significantCharacters++;
+            }
+            if (significantCharacters == n) {
                 break;
             }
         }
-        return stringBuilder.toString();
-    }
-
-    private long countSignificantCharacters(String name) {
-        int total = 0;
-        for (char character : name.toCharArray()) {
-            if (!StringUtils.isWhitespace(String.valueOf(character))) {
-                total++;
-            }
-        }
-        return total;
+        return name.substring(0, endIndex);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/PersonName.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/PersonName.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
 
 @AllArgsConstructor
 @Getter
@@ -17,11 +18,28 @@ public class PersonName {
 
     PersonName hmrcNameMatchingEquivalent() {
         String firstInitial = firstNLetters(1, this.firstName);
-        String surnameFirstThreeLetters = firstNLetters(3, this.lastName);
-        return new PersonName(firstInitial, surnameFirstThreeLetters);
+        String surnameFirstThreeSignificantCharacters = firstNLetters(3, this.lastName);
+        return new PersonName(firstInitial, surnameFirstThreeSignificantCharacters);
     }
 
-    private String firstNLetters(int n, String string) {
-        return string.substring(0, Math.min(string.length(), n));
+    private String firstNLetters(int n, String name) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < name.length(); i++) {
+            stringBuilder.append(name, i, i + 1);
+            if (countSignificantCharacters(stringBuilder.toString()) >= n) {
+                break;
+            }
+        }
+        return stringBuilder.toString();
+    }
+
+    private long countSignificantCharacters(String name) {
+        int total = 0;
+        for (char character : name.toCharArray()) {
+            if (!StringUtils.isWhitespace(String.valueOf(character))) {
+                total++;
+            }
+        }
+        return total;
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorFunctionsTest.java
@@ -1,0 +1,76 @@
+package uk.gov.digital.ho.pttg.application.namematching;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.digital.ho.pttg.application.namematching.NameMatchingCandidatesGeneratorFunctions.deduplicate;
+
+public class NameMatchingCandidatesGeneratorFunctionsTest {
+
+    @Test
+    public void deduplicateEmptyListShouldReturnEmptyList() {
+        assertThat(deduplicate(emptyList())).isEqualTo(emptyList());
+    }
+
+    @Test
+    public void deduplicateSingletonListShouldReturnSingletonList() {
+        List<PersonName> singleName = singletonList(new PersonName("any first name", "any last name"));
+        assertThat(deduplicate(singleName)).isEqualTo(singleName);
+    }
+
+    @Test
+    public void deduplicateTwoDistinctItemListShouldReturnTwoDistinctItemList() {
+        List<PersonName> twoDistinctNames = asList(
+                new PersonName("any first name", "any last name"),
+                new PersonName("other first name", "some other last name")
+        );
+        assertThat(deduplicate(twoDistinctNames)).isEqualTo(twoDistinctNames);
+    }
+
+    @Test
+    public void deduplicateSameFirstInitialOnlyShouldKeepAll() {
+        List<PersonName> sameFirstInitialNames = asList(
+                new PersonName("any first name", "any last name"),
+                new PersonName("any other first name", "some other last name")
+        );
+        assertThat(deduplicate(sameFirstInitialNames)).isEqualTo(sameFirstInitialNames);
+    }
+
+    @Test
+    public void deduplicateSameFirstThreeLettersOfSurnameOnlyShouldKeepAll() {
+        List<PersonName> sameFirstInitialNames = asList(
+                new PersonName("any first name", "any last name"),
+                new PersonName("other first name", "any other last name")
+        );
+        assertThat(deduplicate(sameFirstInitialNames)).isEqualTo(sameFirstInitialNames);
+    }
+
+    @Test
+    public void deduplicateShouldRemoveIfSameFirstInitialAndFirstThreeSurnameLetters() {
+        List<PersonName> duplicateNames = asList(
+                new PersonName("any first name", "any last name"),
+                new PersonName("a first name", "any other last name")
+        );
+        List<PersonName> expected = singletonList(new PersonName("any first name", "any last name"));
+        assertThat(deduplicate(duplicateNames)).isEqualTo(expected);
+    }
+
+    @Test
+    public void deduplicateShouldKeepInputOrder() {
+        List<PersonName> duplicateNames = asList(
+                new PersonName("some other name", "some other name"),
+                new PersonName("a first name", "any other last name"),
+                new PersonName("any first name", "any last name")
+        );
+        List<PersonName> expected = asList(
+                new PersonName("some other name", "some other name"),
+                new PersonName("a first name", "any other last name")
+        );
+        assertThat(deduplicate(duplicateNames)).isEqualTo(expected);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorTest.java
@@ -6,17 +6,18 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NameMatchingCandidatesGeneratorTest {
 
     private static final String INCORRECT_ORDER = "The names should be correctly generated in the defined order";
     private static final String INCORRECT_NUMBER_OF_GENERATED_NAMES = "The number of generated names should be as expected";
+    private static final String DEDUPLICATION = "The name should be removed by deduplication";
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldErrorIfNoName() {
@@ -124,14 +125,15 @@ public class NameMatchingCandidatesGeneratorTest {
     public void shouldHandleMultipleLastNames() {
         List<PersonName> names = NameMatchingCandidatesGenerator.generateCandidateNames("Arthur", "Brian Coates");
 
-        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(7));
+        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(6));
         assertThat("The lastname is used unsplit for the first permutation", names.get(0), is(new PersonName("Arthur", "Brian Coates")));
         assertThat(INCORRECT_ORDER, names.get(1), is(new PersonName("Arthur", "Coates")));
         assertThat(INCORRECT_ORDER, names.get(2), is(new PersonName("Brian", "Coates")));
         assertThat(INCORRECT_ORDER, names.get(3), is(new PersonName("Coates", "Arthur")));
         assertThat(INCORRECT_ORDER, names.get(4), is(new PersonName("Coates", "Brian")));
-        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("Arthur", "Brian")));
-        assertThat(INCORRECT_ORDER, names.get(6), is(new PersonName("Brian", "Arthur")));
+        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("Brian", "Arthur")));
+
+        assertThat(DEDUPLICATION, names, not(contains(new PersonName("Arthur", "Brian"))));
 
     }
 
@@ -139,80 +141,81 @@ public class NameMatchingCandidatesGeneratorTest {
     public void shouldHandleHyphenatedNames() {
         List<PersonName> names = NameMatchingCandidatesGenerator.generateCandidateNames("Arthur-Brian", "Coates");
 
-        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(10));
+        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(6));
         assertThat(INCORRECT_ORDER, names.get(0), is(new PersonName("Arthur-Brian", "Coates")));
         assertThat(INCORRECT_ORDER, names.get(1), is(new PersonName("Coates", "Arthur-Brian")));
-        assertThat(INCORRECT_ORDER, names.get(2), is(new PersonName("ArthurBrian", "Coates")));
-        assertThat(INCORRECT_ORDER, names.get(3), is(new PersonName("Coates", "ArthurBrian")));
-        assertThat(INCORRECT_ORDER, names.get(4), is(new PersonName("Arthur", "Coates")));
-        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("Brian", "Coates")));
-        assertThat(INCORRECT_ORDER, names.get(6), is(new PersonName("Coates", "Arthur")));
-        assertThat(INCORRECT_ORDER, names.get(7), is(new PersonName("Coates", "Brian")));
-        assertThat(INCORRECT_ORDER, names.get(8), is(new PersonName("Arthur", "Brian")));
-        assertThat(INCORRECT_ORDER, names.get(9), is(new PersonName("Brian", "Arthur")));
+        assertThat(INCORRECT_ORDER, names.get(2), is(new PersonName("Brian", "Coates")));
+        assertThat(INCORRECT_ORDER, names.get(3), is(new PersonName("Coates", "Brian")));
+        assertThat(INCORRECT_ORDER, names.get(4), is(new PersonName("Arthur", "Brian")));
+        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("Brian", "Arthur")));
+
+        assertThat(DEDUPLICATION, names, not(contains(new PersonName("ArthurBrian", "Coates"))));
+        assertThat(DEDUPLICATION, names, not(contains(new PersonName("Coates", "ArthurBrian"))));
+        assertThat(DEDUPLICATION, names, not(contains(new PersonName("Arthur", "Coates"))));
+        assertThat(DEDUPLICATION, names, not(contains(new PersonName("Coates", "Arthur"))));
     }
 
     @Test
     public void shouldHandleApostrophedNames() {
         List<PersonName> names = NameMatchingCandidatesGenerator.generateCandidateNames("Arthur", "O'Bobbins");
 
-        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(11));
+        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(9));
         assertThat(INCORRECT_ORDER, names.get(0), is(new PersonName("Arthur", "O'Bobbins")));
         assertThat(INCORRECT_ORDER, names.get(1), is(new PersonName("O'Bobbins", "Arthur")));
         assertThat(INCORRECT_ORDER, names.get(2), is(new PersonName("Arthur", "O Bobbins")));
         assertThat(INCORRECT_ORDER, names.get(3), is(new PersonName("Arthur", "OBobbins")));
-        assertThat(INCORRECT_ORDER, names.get(4), is(new PersonName("OBobbins", "Arthur")));
-        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("Arthur", "Bobbins")));
-        assertThat(INCORRECT_ORDER, names.get(6), is(new PersonName("O", "Bobbins")));
-        assertThat(INCORRECT_ORDER, names.get(7), is(new PersonName("Bobbins", "Arthur")));
-        assertThat(INCORRECT_ORDER, names.get(8), is(new PersonName("Bobbins", "O")));
-        assertThat(INCORRECT_ORDER, names.get(9), is(new PersonName("Arthur", "O")));
-        assertThat(INCORRECT_ORDER, names.get(10), is(new PersonName("O", "Arthur")));
+        assertThat(INCORRECT_ORDER, names.get(4), is(new PersonName("Arthur", "Bobbins")));
+        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("O", "Bobbins")));
+        assertThat(INCORRECT_ORDER, names.get(6), is(new PersonName("Bobbins", "Arthur")));
+        assertThat(INCORRECT_ORDER, names.get(7), is(new PersonName("Bobbins", "O")));
+        assertThat(INCORRECT_ORDER, names.get(8), is(new PersonName("Arthur", "O")));
+
+        assertThat(DEDUPLICATION, names, not(contains(new PersonName("OBobbins", "Arthur"))));
+        assertThat(DEDUPLICATION, names, not(contains(new PersonName("O", "Arthur"))));
     }
 
     @Test
     public void shouldHandleHyphensAndApostrophes() {
         List<PersonName> names = NameMatchingCandidatesGenerator.generateCandidateNames("Arthur-Brian", "O'Coates");
 
-        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(19));
+        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(16));
 
         assertThat(INCORRECT_ORDER, names.get(0), is(new PersonName("Arthur-Brian", "O'Coates")));
         assertThat(INCORRECT_ORDER, names.get(1), is(new PersonName("O'Coates", "Arthur-Brian")));
         assertThat(INCORRECT_ORDER, names.get(2), is(new PersonName("Arthur Brian", "O Coates")));
-        assertThat(INCORRECT_ORDER, names.get(3), is(new PersonName("Arthur", "O Coates")));
-        assertThat(INCORRECT_ORDER, names.get(4), is(new PersonName("Brian", "O Coates")));
-        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("ArthurBrian", "OCoates")));
-        assertThat(INCORRECT_ORDER, names.get(6), is(new PersonName("OCoates", "ArthurBrian")));
-        assertThat(INCORRECT_ORDER, names.get(7), is(new PersonName("Arthur", "Coates")));
-        assertThat(INCORRECT_ORDER, names.get(8), is(new PersonName("Brian", "Coates")));
-        assertThat(INCORRECT_ORDER, names.get(9), is(new PersonName("O", "Coates")));
-        assertThat(INCORRECT_ORDER, names.get(10), is(new PersonName("Arthur", "Brian")));
-        assertThat(INCORRECT_ORDER, names.get(11), is(new PersonName("Arthur", "O")));
-        assertThat(INCORRECT_ORDER, names.get(12), is(new PersonName("Brian", "Arthur")));
-        assertThat(INCORRECT_ORDER, names.get(13), is(new PersonName("O", "Arthur")));
-        assertThat(INCORRECT_ORDER, names.get(14), is(new PersonName("Coates", "Arthur")));
-        assertThat(INCORRECT_ORDER, names.get(15), is(new PersonName("Brian", "O")));
-        assertThat(INCORRECT_ORDER, names.get(16), is(new PersonName("O", "Brian")));
-        assertThat(INCORRECT_ORDER, names.get(17), is(new PersonName("Coates", "Brian")));
-        assertThat(INCORRECT_ORDER, names.get(18), is(new PersonName("Coates", "O")));
+        assertThat(INCORRECT_ORDER, names.get(3), is(new PersonName("Brian", "O Coates")));
+        assertThat(INCORRECT_ORDER, names.get(4), is(new PersonName("ArthurBrian", "OCoates")));
+        assertThat(INCORRECT_ORDER, names.get(5), is(new PersonName("Arthur", "Coates")));
+        assertThat(INCORRECT_ORDER, names.get(6), is(new PersonName("Brian", "Coates")));
+        assertThat(INCORRECT_ORDER, names.get(7), is(new PersonName("O", "Coates")));
+        assertThat(INCORRECT_ORDER, names.get(8), is(new PersonName("Arthur", "Brian")));
+        assertThat(INCORRECT_ORDER, names.get(9), is(new PersonName("Arthur", "O")));
+        assertThat(INCORRECT_ORDER, names.get(10), is(new PersonName("Brian", "Arthur")));
+        assertThat(INCORRECT_ORDER, names.get(11), is(new PersonName("Coates", "Arthur")));
+        assertThat(INCORRECT_ORDER, names.get(12), is(new PersonName("Brian", "O")));
+        assertThat(INCORRECT_ORDER, names.get(13), is(new PersonName("O", "Brian")));
+        assertThat(INCORRECT_ORDER, names.get(14), is(new PersonName("Coates", "Brian")));
+        assertThat(INCORRECT_ORDER, names.get(15), is(new PersonName("Coates", "O")));
+
+        assertThat(DEDUPLICATION, names, not(is(new PersonName("Arthur", "O Coates"))));
+        assertThat(DEDUPLICATION, names, not(is(new PersonName("OCoates", "ArthurBrian"))));
+        assertThat(DEDUPLICATION, names, not(is(new PersonName("O", "Arthur"))));
     }
 
     @Test
     public void shouldUseFirstFourAndLastThreeNamesIfOverSevenProvided() {
         List<PersonName> candidateNames = NameMatchingCandidatesGenerator.generateCandidateNames("A B C D E", "F G H");
 
-        assertThat(candidateNames.size(), is(71));
+        assertThat(candidateNames, hasItems(
+                new PersonName("A B C D", "F G H"),
+                new PersonName("B", "F G H"),
+                new PersonName("C", "F G H"),
+                new PersonName("D", "F G H")
+        ));
+        assertThat(DEDUPLICATION, candidateNames, not(hasItem(new PersonName("A", "F G H"))));
 
-        candidateNames = candidateNames.stream().
-                filter(name -> !name.lastName().equals("F G H")).
-                collect(Collectors.toList());
-
-        assertThat(candidateNames.size(), is(66)); // Expect there to be 5 candidates of retained first names paired with the entire lastname "F G H"
-
-        for (PersonName name : candidateNames) {
-            assertThat(name.firstName().contains("E"), is(false));
-            assertThat(name.lastName().contains("E"), is(false));
-        }
+        assertThat(candidateNames.stream().noneMatch(candidateName -> candidateName.firstName().equals("E")), is(true));
+        assertThat(candidateNames.stream().noneMatch(candidateName -> candidateName.lastName().equals("E")), is(true));
     }
 
     @Test
@@ -233,7 +236,7 @@ public class NameMatchingCandidatesGeneratorTest {
         );
 
         for (PersonName expectedCandidateName : expectedCandidateNames) {
-            assertThat(candidateNames.contains(expectedCandidateName), is(true));
+            assertThat(containsHmrcEquivalentName(candidateNames, expectedCandidateName), is(true));
         }
 
         assertThat(candidateNames.contains(new PersonName("E", "Van")), is(false));
@@ -246,11 +249,10 @@ public class NameMatchingCandidatesGeneratorTest {
     public void shouldUseJoiningInBothNamesWithSuppliedNamesAsFirstAttempt() {
         List<PersonName> names = NameMatchingCandidatesGenerator.generateCandidateNames("Bob-Brian", "Hill O'Coates-Smith");
 
-        assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(53));
-
         assertThat(INCORRECT_ORDER, names.get(0), is(new PersonName("Bob-Brian", "Hill O'Coates-Smith")));
 
         Assertions.assertThat(names).doesNotHaveDuplicates();
+        assertThat(DEDUPLICATION, containsHmrcDuplicateNames(names), is(false));
     }
 
     @Test
@@ -282,4 +284,17 @@ public class NameMatchingCandidatesGeneratorTest {
         assertThat(INCORRECT_ORDER, names.get(21), is(new PersonName("C", "F E")));
     }
 
+    private boolean containsHmrcEquivalentName(Collection<PersonName> candidateNames, PersonName expectedName) {
+        return candidateNames.stream()
+                .anyMatch(name -> name.hmrcNameMatchingEquivalent().equals(expectedName.hmrcNameMatchingEquivalent()));
+    }
+
+    private boolean containsHmrcDuplicateNames(Collection<PersonName> candidateNames) {
+        int totalNames = candidateNames.size();
+        long totalDedupedNames = candidateNames.stream()
+                .map(PersonName::hmrcNameMatchingEquivalent)
+                .distinct()
+                .count();
+        return totalNames > totalDedupedNames;
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesGeneratorTest.java
@@ -203,16 +203,20 @@ public class NameMatchingCandidatesGeneratorTest {
     }
 
     @Test
-    public void shouldUseFirstFourAndLastThreeNamesIfOverSevenProvided() {
+    public void shouldUseEntireMultiWordSurname() {
         List<PersonName> candidateNames = NameMatchingCandidatesGenerator.generateCandidateNames("A B C D E", "F G H");
-
+        assertThat(INCORRECT_ORDER, candidateNames.get(0), equalTo(new PersonName("A B C D", "F G H")));
         assertThat(candidateNames, hasItems(
-                new PersonName("A B C D", "F G H"),
                 new PersonName("B", "F G H"),
                 new PersonName("C", "F G H"),
                 new PersonName("D", "F G H")
         ));
         assertThat(DEDUPLICATION, candidateNames, not(hasItem(new PersonName("A", "F G H"))));
+    }
+
+    @Test
+    public void shouldUseFirstFourAndLastThreeNamesIfOverSevenProvided() {
+        List<PersonName> candidateNames = NameMatchingCandidatesGenerator.generateCandidateNames("A B C D E", "F G H");
 
         assertThat(candidateNames.stream().noneMatch(candidateName -> candidateName.firstName().equals("E")), is(true));
         assertThat(candidateNames.stream().noneMatch(candidateName -> candidateName.lastName().equals("E")), is(true));

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/PersonNameTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/PersonNameTest.java
@@ -1,0 +1,40 @@
+package uk.gov.digital.ho.pttg.application.namematching;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PersonNameTest {
+
+    @Test
+    public void emptyNameHmrcEquivalentShouldBeEmptyName() {
+        PersonName emptyName = new PersonName("", "");
+        assertThat(emptyName.hmrcNameMatchingEquivalent()).isEqualTo(emptyName);
+    }
+
+    @Test
+    public void oneCharacterFirstAndSurnameHmrcEquivalentShouldBeSame() {
+        PersonName oneCharNames = new PersonName("a", "b");
+        assertThat(oneCharNames.hmrcNameMatchingEquivalent()).isEqualTo(oneCharNames);
+    }
+
+    @Test
+    public void oneCharacterFirstAndThreeCharacterSurnameHmrcEquivalentShouldBeSame() {
+        PersonName inputName = new PersonName("a", "bcd");
+        assertThat(inputName.hmrcNameMatchingEquivalent()).isEqualTo(inputName);
+    }
+
+    @Test
+    public void hmrcEquivalentSurnameShouldOnlyUseFirstInitial() {
+        PersonName inputName = new PersonName("ab", "cde");
+        PersonName expected = new PersonName("a", "cde");
+        assertThat(inputName.hmrcNameMatchingEquivalent()).isEqualTo(expected);
+    }
+
+    @Test
+    public void hmrcEquivalentSurnameShouldOnlyUseFirstThreeSurnameLetters() {
+        PersonName inputName = new PersonName("a", "cdefg");
+        PersonName expected = new PersonName("a", "cde");
+        assertThat(inputName.hmrcNameMatchingEquivalent()).isEqualTo(expected);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/PersonNameTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/PersonNameTest.java
@@ -37,4 +37,11 @@ public class PersonNameTest {
         PersonName expected = new PersonName("a", "cde");
         assertThat(inputName.hmrcNameMatchingEquivalent()).isEqualTo(expected);
     }
+
+    @Test
+    public void hmrcEquivalentSurnameShouldUseFirstThreeSignificantSurnameCharacters() {
+        PersonName inputName = new PersonName("a", "cd efg");
+        PersonName expected = new PersonName("a", "cd e");
+        assertThat(inputName.hmrcNameMatchingEquivalent()).isEqualTo(expected);
+    }
 }

--- a/src/test/resources/specs/name-matching/Name_6Strings_HMRC.feature
+++ b/src/test/resources/specs/name-matching/Name_6Strings_HMRC.feature
@@ -14,7 +14,6 @@ Feature: Name matching with 6 name strings
     Then the footprint will try the following combination of names in order
       | First name  | Last name   | Date of Birth | nino        |
       | Aaa Bbb Ccc | Ddd Eee Fff | 1987-12-10    | SE 123456 B |
-      | Aaa         | Ddd Eee Fff | 1987-12-10    | SE 123456 B |
       | Bbb         | Ddd Eee Fff | 1987-12-10    | SE 123456 B |
       | Ccc         | Ddd Eee Fff | 1987-12-10    | SE 123456 B |
       | Aaa         | Fff         | 1987-12-10    | SE 123456 B |
@@ -23,15 +22,12 @@ Feature: Name matching with 6 name strings
       | Ddd         | Fff         | 1987-12-10    | SE 123456 B |
       | Aaa         | Bbb         | 1987-12-10    | SE 123456 B |
       | Aaa         | Ccc         | 1987-12-10    | SE 123456 B |
-      | Aaa         | Ddd         | 1987-12-10    | SE 123456 B |
       | Aaa         | Eee         | 1987-12-10    | SE 123456 B |
       | Bbb         | Aaa         | 1987-12-10    | SE 123456 B |
       | Bbb         | Ccc         | 1987-12-10    | SE 123456 B |
-      | Bbb         | Ddd         | 1987-12-10    | SE 123456 B |
       | Bbb         | Eee         | 1987-12-10    | SE 123456 B |
       | Ccc         | Aaa         | 1987-12-10    | SE 123456 B |
       | Ccc         | Bbb         | 1987-12-10    | SE 123456 B |
-      | Ccc         | Ddd         | 1987-12-10    | SE 123456 B |
       | Ccc         | Eee         | 1987-12-10    | SE 123456 B |
       | Ddd         | Aaa         | 1987-12-10    | SE 123456 B |
       | Ddd         | Bbb         | 1987-12-10    | SE 123456 B |
@@ -48,4 +44,4 @@ Feature: Name matching with 6 name strings
       | Fff         | Ddd         | 1987-12-10    | SE 123456 B |
       | Fff         | Eee         | 1987-12-10    | SE 123456 B |
     And a Matched response will be returned from the service
-    And HMRC was called 34 times
+    And HMRC was called 30 times

--- a/src/test/resources/specs/name-matching/Name_7Strings_HMRC.feature
+++ b/src/test/resources/specs/name-matching/Name_7Strings_HMRC.feature
@@ -33,7 +33,6 @@ Feature: Name matching with 7 name strings
     Then the footprint will try the following combination of names in order
       | First name      | Last name   | Date of Birth | nino        |
       | Aaa Bbb Ccc Ddd | Eee Fff Ggg | 1987-12-10    | SE 123456 B |
-      | Aaa             | Eee Fff Ggg | 1987-12-10    | SE 123456 B |
       | Bbb             | Eee Fff Ggg | 1987-12-10    | SE 123456 B |
       | Ccc             | Eee Fff Ggg | 1987-12-10    | SE 123456 B |
       | Ddd             | Eee Fff Ggg | 1987-12-10    | SE 123456 B |
@@ -46,22 +45,18 @@ Feature: Name matching with 7 name strings
       | Aaa             | Bbb         | 1987-12-10    | SE 123456 B |
       | Aaa             | Ccc         | 1987-12-10    | SE 123456 B |
       | Aaa             | Ddd         | 1987-12-10    | SE 123456 B |
-      | Aaa             | Eee         | 1987-12-10    | SE 123456 B |
       | Aaa             | Fff         | 1987-12-10    | SE 123456 B |
       | Bbb             | Aaa         | 1987-12-10    | SE 123456 B |
       | Bbb             | Ccc         | 1987-12-10    | SE 123456 B |
       | Bbb             | Ddd         | 1987-12-10    | SE 123456 B |
-      | Bbb             | Eee         | 1987-12-10    | SE 123456 B |
       | Bbb             | Fff         | 1987-12-10    | SE 123456 B |
       | Ccc             | Aaa         | 1987-12-10    | SE 123456 B |
       | Ccc             | Bbb         | 1987-12-10    | SE 123456 B |
       | Ccc             | Ddd         | 1987-12-10    | SE 123456 B |
-      | Ccc             | Eee         | 1987-12-10    | SE 123456 B |
       | Ccc             | Fff         | 1987-12-10    | SE 123456 B |
       | Ddd             | Aaa         | 1987-12-10    | SE 123456 B |
       | Ddd             | Bbb         | 1987-12-10    | SE 123456 B |
       | Ddd             | Ccc         | 1987-12-10    | SE 123456 B |
-      | Ddd             | Eee         | 1987-12-10    | SE 123456 B |
       | Ddd             | Fff         | 1987-12-10    | SE 123456 B |
       | Eee             | Aaa         | 1987-12-10    | SE 123456 B |
       | Eee             | Bbb         | 1987-12-10    | SE 123456 B |
@@ -83,7 +78,7 @@ Feature: Name matching with 7 name strings
 
 
   @name_matching
-  Scenario: Applicant with 7 names is matched in HMRC after trying 38 name combinations
+  Scenario: Applicant with 7 names is matched in HMRC after trying 34 name combinations
     Given HMRC has the following individual records
       | First name | Last name | Date of Birth | nino        |
       | Fff        | Ccc       | 1987-12-10    | SE 123456 B |
@@ -93,7 +88,7 @@ Feature: Name matching with 7 name strings
       | Date of Birth | 1987-12-10      |
       | nino          | SE 123456 B     |
     Then a Matched response will be returned from the service
-    And HMRC was called 39 times
+    And HMRC was called 34 times
 
 
   @name_matching
@@ -107,7 +102,7 @@ Feature: Name matching with 7 name strings
       | Date of Birth | 1987-12-10      |
       | nino          | SE 123456 B     |
     Then a not matched response is returned
-    And HMRC was called 47 times
+    And HMRC was called 42 times
 
 
   @name_matching
@@ -121,7 +116,7 @@ Feature: Name matching with 7 name strings
       | Date of Birth | 1987-12-10                        |
       | nino          | SE 123456 B                       |
     Then a Matched response will be returned from the service
-    And HMRC was called 11 times
+    And HMRC was called 10 times
 
 
   @name_matching
@@ -135,7 +130,7 @@ Feature: Name matching with 7 name strings
       | Date of Birth | 1987-12-10                        |
       | nino          | SE 123456 B                       |
     Then a Matched response will be returned from the service
-    And HMRC was called 7 times
+    And HMRC was called 6 times
 
   @name_matching
   Scenario: Applicant with a hyphenated first name is matched in HMRC on the hyphenated version of the name
@@ -148,7 +143,7 @@ Feature: Name matching with 7 name strings
       | Date of Birth | 1987-12-10                        |
       | nino          | SE 123456 B                       |
     Then a Matched response will be returned from the service
-    And HMRC was called 7 times
+    And HMRC was called 6 times
 
   @name_matching
   Scenario: Applicant with a hyphenated last name is matched in HMRC on the hyphenated version of the name
@@ -175,4 +170,4 @@ Feature: Name matching with 7 name strings
       | Date of Birth | 1987-12-10                        |
       | nino          | SE 123456 B                       |
     Then a not matched response is returned
-    And HMRC was called 47 times
+    And HMRC was called 42 times

--- a/src/test/resources/specs/name-matching/Name_Matching_Deduplication.feature
+++ b/src/test/resources/specs/name-matching/Name_Matching_Deduplication.feature
@@ -1,0 +1,34 @@
+Feature: Name matching does not attempt matches that are duplicates from HMRC's point of view.
+
+  Scenario: First names starting with same letter does not produce duplicate matching calls to HMRC.
+    Given HMRC has the following individual records
+      | First name | Last name | Date of Birth | nino        |
+      | Bert       | Evans     | 1987-12-10    | SE 123456 B |
+    When the applicant submits the following data to the RPS service
+      | First name    | Alex Andrew |
+      | Last name     | Evans       |
+      | Date of Birth | 1987-12-10  |
+      | nino          | SE 123456 B |
+    Then the footprint will try the following combination of names in order
+      | First name | Last name | Date of Birth | nino        |
+      | Alex       | Evans     | 1987-12-10    | SE 123456 B |
+      | Evans      | Alex      | 1987-12-10    | SE 123456 B |
+      | Evans      | Andrew    | 1987-12-10    | SE 123456 B |
+      | Alex       | Andrew    | 1987-12-10    | SE 123456 B |
+      | Andrew     | Alex      | 1987-12-10    | SE 123456 B |
+    And a not matched response is returned
+
+  Scenario: Surnames with same first three letters does not produce duplicate matching calls to HMRC.
+    Given HMRC has the following individual records
+      | First name | Last name   | Date of Birth | nino        |
+      | Bert       | Smith Terry | 1987-12-10    | SE 123456 B |
+    When the applicant submits the following data to the RPS service
+      | First name    | Bert             |
+      | Last name     | Roberts Robinson |
+      | Date of Birth | 1987-12-10       |
+      | nino          | SE 123456 B      |
+    Then the footprint will try the following combination of names in order
+      | First name | Last name        | Date of Birth | nino        |
+      | Bert       | Roberts Robinson | 1987-12-10    | SE 123456 B |
+      | Roberts    | Robinson         | 1987-12-10    | SE 123456 B |
+      | Robinson   | Bert             | 1987-12-10    | SE 123456 B |

--- a/src/test/resources/specs/name-matching/Name_With_Special_Characters.feature
+++ b/src/test/resources/specs/name-matching/Name_With_Special_Characters.feature
@@ -162,13 +162,11 @@ Feature: Accept Hyphens and Apostrophes as part of the name matching
     Then the footprint will try the following combination of names in order
       | First name | Last name | Date of Birth | nino        |
       | Pas Alb    | R De Fey  | 1987-12-10    | SE 123456 B |
-      | Pas        | R De Fey  | 1987-12-10    | SE 123456 B |
-      | Pas        | R De      | 1987-12-10    | SE 123456 B |
       | Pas        | R Fey     | 1987-12-10    | SE 123456 B |
       | Pas        | De R      | 1987-12-10    | SE 123456 B |
       | Pas        | De Fey    | 1987-12-10    | SE 123456 B |
     And a Matched response will be returned from the service
-    And HMRC was called 6 times
+    And HMRC was called 4 times
 
 
   @name_matching
@@ -191,7 +189,6 @@ Feature: Accept Hyphens and Apostrophes as part of the name matching
       | Pas        | Fey            | 1987-12-10    | SE 123456 B |
       | Alb        | Fey            | 1987-12-10    | SE 123456 B |
       | De         | Fey            | 1987-12-10    | SE 123456 B |
-      | R          | Pas            | 1987-12-10    | SE 123456 B |
       | R          | Alb            | 1987-12-10    | SE 123456 B |
       | R          | De             | 1987-12-10    | SE 123456 B |
       | Pas        | R              | 1987-12-10    | SE 123456 B |
@@ -208,4 +205,4 @@ Feature: Accept Hyphens and Apostrophes as part of the name matching
       | Fey        | Alb            | 1987-12-10    | SE 123456 B |
       | Fey        | De             | 1987-12-10    | SE 123456 B |
     Then a not matched response is returned
-    And HMRC was called 24 times
+    And HMRC was called 23 times


### PR DESCRIPTION
Made it so that we don't send Name Matching requests to HMRC that would be effectively duplicates from their point of view. HMRC only consider the first letter of the first name and the first three significant characters of the surname, so the candidate names for matching attempts are deduplicated accordingly.