### PR TITLE
EE-9765 Added the AliasNameCombinations  into the NameMatchingCandidateService

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClient.java
@@ -209,7 +209,7 @@ public class HmrcHateoasClient {
 
         log.info("Match Individual {} via a POST to {}", individual.getNino(), matchUrl, value(EVENT, HMRC_MATCHING_REQUEST_SENT));
 
-        List<CandidateName> candidateNames =   nameMatchingCandidatesService.generateCandidateNames(individual.getFirstName(), individual.getLastName());
+        List<CandidateName> candidateNames =   nameMatchingCandidatesService.generateCandidateNames(individual.getFirstName(), individual.getLastName(), individual.getAliasSurnames());
 
         int retries = 0;
 

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/InputNames.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/InputNames.java
@@ -66,4 +66,8 @@ public class InputNames {
     public String fullLastName() {
         return String.join(" ", lastNames);
     }
+
+    public boolean hasAliasSurnames() {
+        return !aliasSurnames.isEmpty();
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesService.java
@@ -15,21 +15,29 @@ public class NameMatchingCandidatesService {
     private NameMatchingCandidateGenerator nameCombinations;
     private NameMatchingCandidateGenerator multipleLastNames;
     private NameMatchingCandidateGenerator specialCharacters;
+    private NameMatchingCandidateGenerator aliasCombinations;
 
-    public NameMatchingCandidatesService(NameMatchingCandidateGenerator nameCombinations, NameMatchingCandidateGenerator multipleLastNames, NameMatchingCandidateGenerator specialCharacters) {
+    public NameMatchingCandidatesService(NameMatchingCandidateGenerator nameCombinations,
+                                         NameMatchingCandidateGenerator multipleLastNames,
+                                         NameMatchingCandidateGenerator specialCharacters,
+                                         NameMatchingCandidateGenerator aliasCombinations) {
         this.nameCombinations = nameCombinations;
         this.multipleLastNames = multipleLastNames;
         this.specialCharacters = specialCharacters;
+        this.aliasCombinations = aliasCombinations;
     }
 
-    public List<CandidateName> generateCandidateNames(String firstNames, String lastNames) {
+    public List<CandidateName> generateCandidateNames(String firstNames, String lastNames, String aliasSurnames) {
+        InputNames inputNames = new InputNames(firstNames, lastNames, aliasSurnames);
 
-        List<CandidateName> candidates = new ArrayList<>();
+        List<CandidateName> candidates = new ArrayList<>(multipleLastNames.generateCandidates(inputNames));
 
-        InputNames inputNames = new InputNames(firstNames, lastNames);
+        if (inputNames.hasAliasSurnames()) {
+            candidates.addAll(aliasCombinations.generateCandidates(inputNames));
+        } else {
+            candidates.addAll(nameCombinations.generateCandidates(inputNames));
+        }
 
-        candidates.addAll(multipleLastNames.generateCandidates(inputNames));
-        candidates.addAll(nameCombinations.generateCandidates(inputNames));
         candidates.addAll(specialCharacters.generateCandidates(inputNames));
 
         return Collections.unmodifiableList(deduplicate(candidates));

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AliasCombinations.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AliasCombinations.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.pttg.application.namematching.candidates;
 
+import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.pttg.application.namematching.CandidateName;
 import uk.gov.digital.ho.pttg.application.namematching.InputNames;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.AliasCombinationsFunctions.*;
 
+@Component
 public class AliasCombinations implements NameMatchingCandidateGenerator {
 
     @Override

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/InputNamesTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/InputNamesTest.java
@@ -164,4 +164,15 @@ public class InputNamesTest {
         InputNames inputNames = new InputNames("John David", "Smith Evans", "Jones McDonald");
         assertThat(inputNames.allNames()).isEqualTo(Arrays.asList("John", "David", "Smith", "Evans", "Jones", "McDonald"));
     }
+
+    @Test
+    public void hasAliasSurnamesShouldReturnFalseWhenNoAliasSurnames() {
+        InputNames noAliasInputNames = new InputNames("John", "Smith", "");
+        assertThat(noAliasInputNames.hasAliasSurnames()).isFalse();
+    }
+    @Test
+    public void hasAliasSurnamesShouldReturnTrueWhenNoAliasSurnames() {
+        InputNames noAliasInputNames = new InputNames("John", "Smith", "Evans");
+        assertThat(noAliasInputNames.hasAliasSurnames()).isTrue();
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesServiceIT.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.pttg.application.namematching.candidates.AliasCombinations;
 import uk.gov.digital.ho.pttg.application.namematching.candidates.MultipleLastNames;
 import uk.gov.digital.ho.pttg.application.namematching.candidates.NameCombinations;
 import uk.gov.digital.ho.pttg.application.namematching.candidates.SpecialCharacters;
@@ -22,7 +23,8 @@ import static org.hamcrest.Matchers.*;
         NameMatchingCandidatesService.class,
         NameCombinations.class,
         MultipleLastNames.class,
-        SpecialCharacters.class
+        SpecialCharacters.class,
+        AliasCombinations.class
 })
 public class NameMatchingCandidatesServiceIT {
 
@@ -35,7 +37,7 @@ public class NameMatchingCandidatesServiceIT {
 
     @Test
     public void shouldHandleMultipleLastNames() {
-        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur", "Brian Coates");
+        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur", "Brian Coates", "");
 
         assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(6));
         assertThat("The lastname is used unsplit for the first permutation", names.get(0), is(new CandidateName("Arthur", "Brian Coates")));
@@ -51,7 +53,7 @@ public class NameMatchingCandidatesServiceIT {
 
     @Test
     public void shouldHandleHyphenatedNames() {
-        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur-Brian", "Coates");
+        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur-Brian", "Coates", "");
 
         assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(6));
         assertThat(INCORRECT_ORDER, names.get(0), is(new CandidateName("Arthur-Brian", "Coates")));
@@ -69,7 +71,7 @@ public class NameMatchingCandidatesServiceIT {
 
     @Test
     public void shouldHandleApostrophedNames() {
-        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur", "O'Bobbins");
+        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur", "O'Bobbins", "");
 
         assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(9));
         assertThat(INCORRECT_ORDER, names.get(0), is(new CandidateName("Arthur", "O'Bobbins")));
@@ -88,7 +90,7 @@ public class NameMatchingCandidatesServiceIT {
 
     @Test
     public void shouldHandleHyphensAndApostrophes() {
-        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur-Brian", "O'Coates");
+        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Arthur-Brian", "O'Coates", "");
 
         assertThat(INCORRECT_NUMBER_OF_GENERATED_NAMES, names.size(), is(16));
 
@@ -116,7 +118,7 @@ public class NameMatchingCandidatesServiceIT {
 
     @Test
     public void shouldOnlyUseFiveOfSevenNameCandidate() {
-        List<CandidateName> candidateNames = nameMatchingCandidatesService.generateCandidateNames("A B C D E F G", "Van Halen");
+        List<CandidateName> candidateNames = nameMatchingCandidatesService.generateCandidateNames("A B C D E F G", "Van Halen", "");
 
         List<CandidateName> expectedCandidateNames = Arrays.asList(
                 new CandidateName("A", "Van"),
@@ -143,7 +145,7 @@ public class NameMatchingCandidatesServiceIT {
 
     @Test
     public void shouldUseJoiningInBothNamesWithSuppliedNamesAsFirstAttempt() {
-        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Bob-Brian", "Hill O'Coates-Smith");
+        List<CandidateName> names = nameMatchingCandidatesService.generateCandidateNames("Bob-Brian", "Hill O'Coates-Smith", "");
 
         assertThat(INCORRECT_ORDER, names.get(0), is(new CandidateName("Bob-Brian", "Hill O'Coates-Smith")));
 


### PR DESCRIPTION
Wired the AliasNameCombinations bean into the NameMatchingCandidateService and checked that any aliases in the Individual passed to the HmrcHateoasClient are passed through to the service.

Currently the HmrcService does not pass the HmrcClient any aliases meaning no behaviour has changed yet - that PR will follow this.