### PR TITLE
Ee 9349 name with dot space candidate name generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
 
   testCompile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.7'
   testCompile group: 'junit', name: 'junit', version: '4.12'
-  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.5.2'
+  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
   testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.18.0'
   testCompile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
   testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.5'

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/CandidateFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/CandidateFunctions.java
@@ -1,30 +1,40 @@
 package uk.gov.digital.ho.pttg.application.namematching.candidates;
 
+import com.google.common.collect.ImmutableList;
 import uk.gov.digital.ho.pttg.application.namematching.InputNames;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class CandidateFunctions {
+class CandidateFunctions {
 
-    public static InputNames removeAdditionalNamesIfOverMax(InputNames inputNames) {
-        final int MAX_NAMES = 7;
-        final int MAX_LAST_NAMES = 3;
+    private static final int MAX_NAMES = 7;
+    private static final int MAX_LAST_NAMES = 3;
+
+    static InputNames removeAdditionalNamesIfOverMax(InputNames inputNames) {
 
         if (inputNames.size() <= MAX_NAMES) {
             return inputNames;
         }
 
-        List<String> lastNames =
-                inputNames.lastNames().stream()
-                        .limit(MAX_LAST_NAMES)
-                        .collect(Collectors.toList());
+        List<String> lastNames = getMaxPermittedSurnames(inputNames.lastNames());
 
-        List<String> firstNames =
-                inputNames.firstNames().stream()
-                        .limit(MAX_NAMES - lastNames.size())
-                        .collect(Collectors.toList());
+        List<String> firstNames = getMaxPermittedFirstNames(inputNames.firstNames(), lastNames.size());
 
         return new InputNames(firstNames, lastNames);
+    }
+
+    private static List<String> getMaxPermittedSurnames(List<String> surnames) {
+        List<String> reversedRetainedSurnames = ImmutableList.copyOf(surnames).reverse().stream()
+                .limit(MAX_LAST_NAMES)
+                .collect(Collectors.toList());
+
+        return ImmutableList.copyOf(reversedRetainedSurnames).reverse();
+    }
+
+    private static List<String> getMaxPermittedFirstNames(List<String> firstNames, int numberOfRetainedLastNames) {
+        return firstNames.stream()
+                .limit(MAX_NAMES - numberOfRetainedLastNames)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinations.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinations.java
@@ -1,0 +1,34 @@
+package uk.gov.digital.ho.pttg.application.namematching.candidates;
+
+import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.pttg.application.namematching.CandidateName;
+import uk.gov.digital.ho.pttg.application.namematching.InputNames;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static uk.gov.digital.ho.pttg.application.namematching.candidates.NamesWithFullStopSpaceCombinationsFunctions.doesNotContainFullStopSpaceBetweenNames;
+import static uk.gov.digital.ho.pttg.application.namematching.candidates.NamesWithFullStopSpaceCombinationsFunctions.splitNamesIgnoringFullStopSpace;
+
+@Component
+public class NamesWithFullStopSpaceCombinations implements NameMatchingCandidateGenerator {
+
+    private final NameCombinations nameCombinations;
+
+    public NamesWithFullStopSpaceCombinations(NameCombinations nameCombinations) {
+        this.nameCombinations = nameCombinations;
+    }
+
+    @Override
+    public List<CandidateName> generateCandidates(InputNames inputNames) {
+        if (doesNotContainFullStopSpaceBetweenNames(inputNames)) {
+            return emptyList();
+        }
+
+        List<String> firstNames = splitNamesIgnoringFullStopSpace(inputNames.fullFirstName());
+        List<String> lastNames = splitNamesIgnoringFullStopSpace(inputNames.fullLastName());
+
+        return nameCombinations.generateCandidates(new InputNames(firstNames, lastNames));
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctions.java
@@ -1,0 +1,43 @@
+package uk.gov.digital.ho.pttg.application.namematching.candidates;
+
+import uk.gov.digital.ho.pttg.application.namematching.InputNames;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+
+final class NamesWithFullStopSpaceCombinationsFunctions {
+
+    private static final String ANY_LETTER_INCLUDING_UNICODE_MATCHER = "\\p{L}\\p{M}*+";
+    private static final String FULL_STOP_SPACE_MATCHER = "\\.\\s+";
+    private static final String FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + FULL_STOP_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
+
+    private static final String FULL_STOP_SPACE_NEGATIVE_LOOK_BEHIND = "(?<!(\\.|\\s))";
+    private static final String SPACE_NOT_PRECEDED_BY_FULL_STOP_OR_SPACE_PATTERN = FULL_STOP_SPACE_NEGATIVE_LOOK_BEHIND + "\\s+";
+
+    static boolean doesNotContainFullStopSpaceBetweenNames(InputNames inputNames) {
+        return nameDoesNotContainFullStopSpaceBetweenNames(inputNames.fullFirstName()) && nameDoesNotContainFullStopSpaceBetweenNames(inputNames.fullLastName());
+    }
+
+    private static boolean nameDoesNotContainFullStopSpaceBetweenNames(String s) {
+        return !Pattern.compile(FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN).matcher(s).find();
+    }
+
+    static List<String> splitNamesIgnoringFullStopSpace(String names) {
+        if (names.isEmpty()) {
+            return emptyList();
+        }
+        String[] splitNames = names.split(SPACE_NOT_PRECEDED_BY_FULL_STOP_OR_SPACE_PATTERN);
+
+        return Arrays.stream(splitNames)
+                .map(NamesWithFullStopSpaceCombinationsFunctions::removeMultipleSpaces)
+                .collect(Collectors.toList());
+    }
+
+    private static String removeMultipleSpaces(String name) {
+        return name.replaceAll("\\s+", " ");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/CandidateFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/CandidateFunctionsTest.java
@@ -5,8 +5,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import uk.gov.digital.ho.pttg.application.namematching.InputNames;
 
-import java.util.Arrays;
-
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.CandidateFunctions.removeAdditionalNamesIfOverMax;
 
@@ -15,7 +14,7 @@ public class CandidateFunctionsTest {
 
     @Test
     public void removeAdditionalNamesOverMax_belowMax() {
-        InputNames afterRemoved = removeAdditionalNamesIfOverMax(new InputNames(Arrays.asList("one", "two", "three", "four"), Arrays.asList("five", "six", "seven")));
+        InputNames afterRemoved = removeAdditionalNamesIfOverMax(new InputNames(asList("one", "two", "three", "four"), asList("five", "six", "seven")));
 
         assertThat(afterRemoved.size()).isEqualTo(7);
         assertThat(afterRemoved.allNames().get(0)).isEqualTo("one");
@@ -26,7 +25,7 @@ public class CandidateFunctionsTest {
 
     @Test
     public void removeAdditionalNamesOverMax_overMax() {
-        InputNames afterRemoved = removeAdditionalNamesIfOverMax(new InputNames(Arrays.asList("one", "two", "three", "four", "extra-one"), Arrays.asList("five", "six", "seven")));
+        InputNames afterRemoved = removeAdditionalNamesIfOverMax(new InputNames(asList("one", "two", "three", "four", "extra-one"), asList("extra-two", "five", "six", "seven")));
 
         assertThat(afterRemoved.size()).isEqualTo(7);
         assertThat(afterRemoved.allNames().get(0)).isEqualTo("one");
@@ -34,5 +33,4 @@ public class CandidateFunctionsTest {
         assertThat(afterRemoved.allNames().get(4)).isEqualTo("five");
         assertThat(afterRemoved.allNames().get(6)).isEqualTo("seven");
     }
-
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest.java
@@ -69,7 +69,7 @@ public class NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_accentedCharactersAtBoundary_returnTrue() {
+    public void doesNotContainFullStopSpaceBetweenNames_accentedCharactersAtBoundary_returnFalse() {
         InputNames accentBeforeFullStop = new InputNames("à. b", "Smith");
         InputNames accentAfterFullStop = new InputNames("David", "b. à");
         assertThat(doesNotContainFullStopSpaceBetweenNames(accentBeforeFullStop)).isFalse();

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest.java
@@ -46,14 +46,14 @@ public class NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest
 
     @Test
     public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceFirstName_returnFalse() {
-        InputNames amesWithFullStopSpaceFirstName = new InputNames("St. John", "Smith");
-        assertThat(doesNotContainFullStopSpaceBetweenNames(amesWithFullStopSpaceFirstName)).isFalse();
+        InputNames namesWithFullStopSpaceFirstName = new InputNames("St. John", "Smith");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(namesWithFullStopSpaceFirstName)).isFalse();
     }
 
     @Test
     public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceLastName_returnFalse() {
-        InputNames amesWithFullStopSpaceLastName = new InputNames("David", "St. John");
-        assertThat(doesNotContainFullStopSpaceBetweenNames(amesWithFullStopSpaceLastName)).isFalse();
+        InputNames namesWithFullStopSpaceLastName = new InputNames("David", "St. John");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(namesWithFullStopSpaceLastName)).isFalse();
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest.java
@@ -1,0 +1,78 @@
+package uk.gov.digital.ho.pttg.application.namematching.candidates;
+
+import org.junit.Test;
+import uk.gov.digital.ho.pttg.application.namematching.InputNames;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.digital.ho.pttg.application.namematching.candidates.NamesWithFullStopSpaceCombinationsFunctions.doesNotContainFullStopSpaceBetweenNames;
+
+public class NamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest {
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_emptyString_returnTrue() {
+        InputNames emptyStringNames = new InputNames("", "");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(emptyStringNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_fullStopOnly_returnTrue() {
+        InputNames fullStopOnlyNames = new InputNames(".", ".");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(fullStopOnlyNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_spaceOnly_returnTrue() {
+        InputNames spaceOnlyNames = new InputNames(" ", " ");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(spaceOnlyNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceNoLetters_returnTrue() {
+        InputNames fullStopSpaceOnlyNames = new InputNames(". ", ". ");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(fullStopSpaceOnlyNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_noNameAfterSpace_returnTrue() {
+        InputNames noNameAfterSpaceNames = new InputNames("St. ", "St. ");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(noNameAfterSpaceNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_noNameBeforeFullStop_returnTrue() {
+        InputNames noNameBeforeFullStopNames = new InputNames(". John", ". John");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(noNameBeforeFullStopNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceFirstName_returnFalse() {
+        InputNames amesWithFullStopSpaceFirstName = new InputNames("St. John", "Smith");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(amesWithFullStopSpaceFirstName)).isFalse();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceLastName_returnFalse() {
+        InputNames amesWithFullStopSpaceLastName = new InputNames("David", "St. John");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(amesWithFullStopSpaceLastName)).isFalse();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_doubleFullStopNotName_returnTrue() {
+        InputNames doubleFullStopNames = new InputNames(".. John", ".. John");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(doubleFullStopNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_fullStopAfterSpaceNotName_returnTrue() {
+        InputNames fullStopAfterSpaceNames = new InputNames("St. .", "St. .");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(fullStopAfterSpaceNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainFullStopSpaceBetweenNames_accentedCharactersAtBoundary_returnTrue() {
+        InputNames accentBeforeFullStop = new InputNames("à. b", "Smith");
+        InputNames accentAfterFullStop = new InputNames("David", "b. à");
+        assertThat(doesNotContainFullStopSpaceBetweenNames(accentBeforeFullStop)).isFalse();
+        assertThat(doesNotContainFullStopSpaceBetweenNames(accentAfterFullStop)).isFalse();
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsSplitNamesTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsFunctionsSplitNamesTest.java
@@ -1,0 +1,63 @@
+package uk.gov.digital.ho.pttg.application.namematching.candidates;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.digital.ho.pttg.application.namematching.candidates.NamesWithFullStopSpaceCombinationsFunctions.splitNamesIgnoringFullStopSpace;
+
+public class NamesWithFullStopSpaceCombinationsFunctionsSplitNamesTest {
+
+    @Test
+    public void splitNamesIgnoringFullStopSpace_emptyName_returnEmptyList() {
+        assertThat(splitNamesIgnoringFullStopSpace("")).isEmpty();
+    }
+
+    @Test
+    public void splitNamesIgnoringFullStopSpace_twoNames_returnAsList() {
+        String twoNames = "John Smith";
+        List<String> expected = asList("John", "Smith");
+
+        assertThat(splitNamesIgnoringFullStopSpace(twoNames))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringFullStopSpace_fullStopNoSpaceInName_doNotSplit() {
+        String nameWithFullStop = "St.John";
+        List<String> expected = singletonList("St.John");
+
+        assertThat(splitNamesIgnoringFullStopSpace(nameWithFullStop))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringFullStopSpace_fullStopSpaceInName_doNotSplit() {
+        String nameWithFullStop = "St. John";
+        List<String> expected = singletonList("St. John");
+
+        assertThat(splitNamesIgnoringFullStopSpace(nameWithFullStop))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringFullStopSpace_multipleSpacesAfterFullStop_reduceToSingleSpace() {
+        String nameWithTwoSpaces = "St.  John";
+        List<String> expected = singletonList("St. John");
+
+        assertThat(splitNamesIgnoringFullStopSpace(nameWithTwoSpaces))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringFullStopSpace_tabAfterFullStop_changeToSingleSpace() {
+        String nameWithTwoSpaces = "St.\tJohn";
+        List<String> expected = singletonList("St. John");
+
+        assertThat(splitNamesIgnoringFullStopSpace(nameWithTwoSpaces))
+                .isEqualTo(expected);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithFullStopSpaceCombinationsTest.java
@@ -1,0 +1,83 @@
+package uk.gov.digital.ho.pttg.application.namematching.candidates;
+
+import org.junit.Test;
+import uk.gov.digital.ho.pttg.application.namematching.CandidateName;
+import uk.gov.digital.ho.pttg.application.namematching.InputNames;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NamesWithFullStopSpaceCombinationsTest {
+
+    private NamesWithFullStopSpaceCombinations namesWithFullStopSpaceCombinations = new NamesWithFullStopSpaceCombinations(new NameCombinations());
+
+    @Test
+    public void shouldReturnEmptyListWhenNoFullStopsInInputNames() {
+        InputNames inputNames = new InputNames("John", "Smith");
+        assertThat(namesWithFullStopSpaceCombinations.generateCandidates(inputNames)).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenNamesAreOnlyFullStops() {
+        InputNames inputNames = new InputNames(".", ".");
+        assertThat(namesWithFullStopSpaceCombinations.generateCandidates(inputNames)).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenFullStopAtVeryEndOfName() {
+        InputNames fullStopEndOfFirstName = new InputNames("John.", "Smith");
+        InputNames fullStopEndOfLastName = new InputNames("John", "Smith.");
+        assertThat(namesWithFullStopSpaceCombinations.generateCandidates(fullStopEndOfFirstName)).isEmpty();
+        assertThat(namesWithFullStopSpaceCombinations.generateCandidates(fullStopEndOfLastName)).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenFullStopNotFollowedBySpace() {
+        InputNames fullStopInFirstName = new InputNames("St.John", "Smith");
+        InputNames fullStopInLastName = new InputNames("David", "St.John");
+        assertThat(namesWithFullStopSpaceCombinations.generateCandidates(fullStopInFirstName)).isEmpty();
+        assertThat(namesWithFullStopSpaceCombinations.generateCandidates(fullStopInLastName)).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnCorrectCombinationWhenFullStopFollowedBySpaceFirstName() {
+        InputNames fullStopInFirstName = new InputNames("St. John", "Smith");
+        List<CandidateName> expected = asList(
+                new CandidateName("St. John", "Smith"),
+                new CandidateName("Smith", "St. John")
+        );
+
+        assertThat(namesWithFullStopSpaceCombinations.generateCandidates(fullStopInFirstName)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldOnlyUseFirst4ForenamesAndLast3SurnamesIfOver7NamesAfterSplitting() {
+        List<String> firstNames = asList("St. John", "Dr. Pepper", "Mr. Mister", "An. Other", "Dr. No");
+        List<String> lastNames = asList("Ms. Smith", "Mr. Jones", "Sgt. Price", "Dme. Bassey");
+        InputNames inputNames = new InputNames(firstNames, lastNames);
+
+        List<CandidateName> candidateNames = namesWithFullStopSpaceCombinations.generateCandidates(inputNames);
+        assertNamePresentInCandidateNames(candidateNames, "St. John", "Dr. Pepper", "Mr. Mister", "An. Other", "Mr. Jones", "Sgt. Price", "Dme. Bassey");
+        assertNameNotPresentInCandidateNames(candidateNames, "Dr. No", "Ms. Smith");
+    }
+
+    private void assertNameNotPresentInCandidateNames(List<CandidateName> candidateNames, String... names) {
+        for (String name : names) {
+            assertThat(candidateNames)
+                    .noneMatch(
+                            candidateName -> candidateName.firstName().equals(name) || candidateName.lastName().equals(name)
+                    );
+        }
+    }
+
+    private void assertNamePresentInCandidateNames(List<CandidateName> candidateNames, String... names) {
+        for (String name : names) {
+            assertThat(candidateNames)
+                    .anyMatch(
+                            candidateName -> candidateName.firstName().equals(name) || candidateName.lastName().equals(name)
+                    );
+        }
+    }
+}


### PR DESCRIPTION
Implemented a new Name Matching Candidates Generator which will take names containing full stop an space and treat them as a single word in name matching (e.g. "St. John").

- I have updated the version of assertJ so that the noneMatch and anyMatch assertions are available

- Also I have fixed a bug in removeNamesIfOverMax method where the first 3 surnames were retained when it should be the last 3. 

-Aliases are not handled by this generator - I will do that in a separate PR
