### PR TITLE
Ee 9349 wire in name with full stop space generator

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesService.java
@@ -17,17 +17,20 @@ public class NameMatchingCandidatesService {
     private NameMatchingCandidateGenerator specialCharacters;
     private NameMatchingCandidateGenerator aliasCombinations;
     private NameMatchingCandidateGenerator entireNonAliasName;
+    private NameMatchingCandidateGenerator namesWithFullStopSpaceCombinations;
 
     public NameMatchingCandidatesService(NameMatchingCandidateGenerator nameCombinations,
                                          NameMatchingCandidateGenerator multipleLastNames,
                                          NameMatchingCandidateGenerator specialCharacters,
                                          NameMatchingCandidateGenerator aliasCombinations,
-                                         NameMatchingCandidateGenerator entireNonAliasName) {
+                                         NameMatchingCandidateGenerator entireNonAliasName,
+                                         NameMatchingCandidateGenerator namesWithFullStopSpaceCombinations) {
         this.nameCombinations = nameCombinations;
         this.multipleLastNames = multipleLastNames;
         this.specialCharacters = specialCharacters;
         this.aliasCombinations = aliasCombinations;
         this.entireNonAliasName = entireNonAliasName;
+        this.namesWithFullStopSpaceCombinations = namesWithFullStopSpaceCombinations;
     }
 
     public List<CandidateName> generateCandidateNames(String firstNames, String lastNames, String aliasSurnames) {
@@ -36,6 +39,8 @@ public class NameMatchingCandidatesService {
         List<CandidateName> candidates = new ArrayList<>(entireNonAliasName.generateCandidates(inputNames));
 
         candidates.addAll(multipleLastNames.generateCandidates(inputNames));
+
+        candidates.addAll(namesWithFullStopSpaceCombinations.generateCandidates(inputNames));
 
         if (inputNames.hasAliasSurnames()) {
             candidates.addAll(aliasCombinations.generateCandidates(inputNames));

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesServiceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesServiceIT.java
@@ -22,7 +22,8 @@ import static org.hamcrest.Matchers.*;
         MultipleLastNames.class,
         SpecialCharacters.class,
         AliasCombinations.class,
-        EntireNonAliasName.class
+        EntireNonAliasName.class,
+        NamesWithFullStopSpaceCombinations.class
 })
 public class NameMatchingCandidatesServiceIT {
 

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/NameMatchingCandidatesServiceTest.java
@@ -30,10 +30,13 @@ public class NameMatchingCandidatesServiceTest {
     private AliasCombinations aliasCombinations;
     @Mock
     private EntireNonAliasName entireNonAliasName;
+    @Mock
+    private NamesWithFullStopSpaceCombinations namesWithFullStopSpaceCombinations;
 
     @Before
     public void setUp() {
-        nameMatchingCandidatesService = new NameMatchingCandidatesService(nameCombinations, multipleLastNames, specialCharacters, aliasCombinations, entireNonAliasName);
+        nameMatchingCandidatesService = new NameMatchingCandidatesService(nameCombinations, multipleLastNames, specialCharacters, aliasCombinations, entireNonAliasName,
+                namesWithFullStopSpaceCombinations);
     }
 
     @Test
@@ -47,6 +50,7 @@ public class NameMatchingCandidatesServiceTest {
         verify(nameCombinations).generateCandidates(expectedInputNames);
         verify(multipleLastNames).generateCandidates(expectedInputNames);
         verify(specialCharacters).generateCandidates(expectedInputNames);
+        verify(namesWithFullStopSpaceCombinations).generateCandidates(expectedInputNames);
 
         verify(aliasCombinations, never()).generateCandidates(any());
     }
@@ -62,6 +66,8 @@ public class NameMatchingCandidatesServiceTest {
         verify(aliasCombinations).generateCandidates(expectedInputNames);
         verify(multipleLastNames).generateCandidates(expectedInputNames);
         verify(specialCharacters).generateCandidates(expectedInputNames);
+        verify(namesWithFullStopSpaceCombinations).generateCandidates(expectedInputNames);
+
 
         verify(nameCombinations, never()).generateCandidates(any());
     }
@@ -83,5 +89,4 @@ public class NameMatchingCandidatesServiceTest {
         assertThat(candidateNames.get(0).firstName().substring(0, 3)).isEqualTo("fir");
         assertThat(candidateNames.get(0).lastName().substring(0, 1)).isEqualTo("l");
     }
-
 }

--- a/src/test/resources/specs/name-matching/Full_stops_in_names.feature
+++ b/src/test/resources/specs/name-matching/Full_stops_in_names.feature
@@ -30,11 +30,11 @@ Feature: Names with full stops
     Then the following identities will be tried in this order
       | First name | Last name | Date of Birth | nino      |
       | Aaa        | Bb. Ccc   | 1987-12-10    | SE123456B |
+      | Bb. Ccc    | Aaa       | 1987-12-10    | SE123456B |
       | Aaa        | Ccc       | 1987-12-10    | SE123456B |
       | Bb.        | Ccc       | 1987-12-10    | SE123456B |
       | Ccc        | Aaa       | 1987-12-10    | SE123456B |
       | Ccc        | Bb.       | 1987-12-10    | SE123456B |
-      | Bb.        | Aaa       | 1987-12-10    | SE123456B |
       | Aaa        | Bb Ccc    | 1987-12-10    | SE123456B |
     And a Matched response will be returned from the service
 
@@ -54,7 +54,6 @@ Feature: Names with full stops
     And a Matched response will be returned from the service
 
   @name_matching
-  @WIP
   Scenario: Name when middle name has a full stop and a space and is matched with HMRC
     Given HMRC has the following individual records
       | First name | Last name | Date of Birth | nino      |
@@ -66,7 +65,7 @@ Feature: Names with full stops
       | nino          | SE123456B   |
     Then the following identities will be tried in this order
       | First name | Last name | Date of Birth | nino      |
-      | Aaa        | Ddd       | 1987-12-10    | SE123456B |
+      | Aaa Bb. Ccc | Ddd       | 1987-12-10    | SE123456B |
       | Bb. Ccc    | Ddd       | 1987-12-10    | SE123456B |
     And a Matched response will be returned from the service
 


### PR DESCRIPTION
Added the new generator into the Name Matching Candidates Service and removed the WIP tag from related BDD.

I have had to slightly tweak the BDD as the order has changed.