### PR TITLE
EE-9349 Moved the joinAllAliasSurnames method

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/InputNames.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/InputNames.java
@@ -67,6 +67,10 @@ public class InputNames {
         return String.join(" ", lastNames);
     }
 
+    public String allAliasSurnamesAsString() {
+        return String.join(" ", aliasSurnames);
+    }
+
     public boolean hasAliasSurnames() {
         return !aliasSurnames.isEmpty();
     }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/SpecialCharacters.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/SpecialCharacters.java
@@ -11,7 +11,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import static uk.gov.digital.ho.pttg.application.namematching.candidates.SpecialCharactersFunctions.joinAllAliasSurnames;
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.SpecialCharactersFunctions.namesAreNotEmpty;
 
 @Component
@@ -63,8 +62,7 @@ public class SpecialCharacters implements NameMatchingCandidateGenerator {
     }
 
     private static boolean namesContainSplitters(InputNames inputNames) {
-        String aliasSurnames = joinAllAliasSurnames(inputNames);
-        return StringUtils.containsAny(inputNames.fullName(), NAME_SPLITTERS) || StringUtils.containsAny(aliasSurnames, NAME_SPLITTERS);
+        return StringUtils.containsAny(inputNames.fullName(), NAME_SPLITTERS) || StringUtils.containsAny(inputNames.allAliasSurnamesAsString(), NAME_SPLITTERS);
     }
 
     private static String nameWithSplittersRemoved(String name) {
@@ -72,8 +70,7 @@ public class SpecialCharacters implements NameMatchingCandidateGenerator {
     }
 
     private static InputNames nameWithSplittersRemoved(InputNames inputNames) {
-        String aliasSurnames = joinAllAliasSurnames(inputNames);
-        return new InputNames(nameWithSplittersRemoved(inputNames.fullFirstName()), nameWithSplittersRemoved(inputNames.fullLastName()), nameWithSplittersRemoved(aliasSurnames));
+        return new InputNames(nameWithSplittersRemoved(inputNames.fullFirstName()), nameWithSplittersRemoved(inputNames.fullLastName()), nameWithSplittersRemoved(inputNames.allAliasSurnamesAsString()));
     }
 
     private static String nameWithSplittersReplacedBySpaces(String name) {
@@ -81,7 +78,7 @@ public class SpecialCharacters implements NameMatchingCandidateGenerator {
     }
 
     private static InputNames nameWithSplittersReplacedBySpaces(InputNames inputNames) {
-        String aliasSurnames = joinAllAliasSurnames(inputNames);
+        String aliasSurnames = inputNames.allAliasSurnamesAsString();
         return new InputNames(nameWithSplittersReplacedBySpaces(inputNames.fullFirstName()), nameWithSplittersReplacedBySpaces(inputNames.fullLastName()), nameWithSplittersReplacedBySpaces(aliasSurnames));
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/SpecialCharactersFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/SpecialCharactersFunctions.java
@@ -6,8 +6,4 @@ final class SpecialCharactersFunctions {
     static boolean namesAreNotEmpty(InputNames inputNames) {
         return !(inputNames.firstNames().isEmpty() && inputNames.lastNames().isEmpty());
     }
-
-    static String joinAllAliasSurnames(InputNames inputNames) {
-        return String.join(" ", inputNames.aliasSurnames());
-    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/InputNamesTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/InputNamesTest.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(MockitoJUnitRunner.class)
 public class InputNamesTest {
 
+    private static final String SOME_NAME = "some name";
+
     @Test
     public void multiPartLastNameEmpty() {
         InputNames inputNames = new InputNames("any-name", "");
@@ -174,5 +176,23 @@ public class InputNamesTest {
     public void hasAliasSurnamesShouldReturnTrueWhenNoAliasSurnames() {
         InputNames noAliasInputNames = new InputNames("John", "Smith", "Evans");
         assertThat(noAliasInputNames.hasAliasSurnames()).isTrue();
+    }
+
+    @Test
+    public void allAliasSurnamesAsString_emptyAliasNames_emptyString() {
+        InputNames emptyAliasNames = new InputNames(SOME_NAME, SOME_NAME, "");
+        assertThat(emptyAliasNames.allAliasSurnamesAsString()).isEmpty();
+    }
+
+    @Test
+    public void allAliasSurnamesAsString_oneAliasNames_aliasNameReturned() {
+        InputNames oneAliasName = new InputNames(SOME_NAME, SOME_NAME, "aliasName");
+        assertThat(oneAliasName.allAliasSurnamesAsString()).isEqualTo("aliasName");
+    }
+
+    @Test
+    public void allAliasSurnamesAsString_twoAliasNames_aliasNamesJoined() {
+        InputNames twoAliasNames = new InputNames(SOME_NAME, SOME_NAME, "aliasName1 aliasName2");
+        assertThat(twoAliasNames.allAliasSurnamesAsString()).isEqualTo("aliasName1 aliasName2");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/SpecialCharactersFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/SpecialCharactersFunctionsTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import uk.gov.digital.ho.pttg.application.namematching.InputNames;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.digital.ho.pttg.application.namematching.candidates.SpecialCharactersFunctions.joinAllAliasSurnames;
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.SpecialCharactersFunctions.namesAreNotEmpty;
 
 public class SpecialCharactersFunctionsTest {
@@ -33,23 +32,5 @@ public class SpecialCharactersFunctionsTest {
     public void namesAreNotEmpty_neitherNameEmpty_isTrue() {
         InputNames emptyLastName = new InputNames(SOME_NAME, SOME_NAME);
         assertThat(namesAreNotEmpty(emptyLastName)).isTrue();
-    }
-
-    @Test
-    public void joinAllAliasSurnames_emptyAliasNames_emptyString() {
-        InputNames emptyAliasNames = new InputNames(SOME_NAME, SOME_NAME, "");
-        assertThat(joinAllAliasSurnames(emptyAliasNames)).isEmpty();
-    }
-
-    @Test
-    public void joinAllAliasSurnames_oneAliasNames_aliasNameReturned() {
-        InputNames oneAliasName = new InputNames(SOME_NAME, SOME_NAME, "aliasName");
-        assertThat(joinAllAliasSurnames(oneAliasName)).isEqualTo("aliasName");
-    }
-
-    @Test
-    public void joinAllAliasSurnames_twoAliasNames_aliasNamesJoined() {
-        InputNames twoAliasNames = new InputNames(SOME_NAME, SOME_NAME, "aliasName1 aliasName2");
-        assertThat(joinAllAliasSurnames(twoAliasNames)).isEqualTo("aliasName1 aliasName2");
     }
 }


### PR DESCRIPTION
Moved the joinAllAliasSurnames method out of SpecialCharactersFunctions and into InputNames where it is now called allAliasSurnamesAsString.

I have done this because I want to use this method in the FullStopSpace Candidate Generator so it doesn't make sense for this to be owned by SpecialCharacters any more. 