### PR TITLE
EE-4133 Added thread_id to all logs

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
@@ -40,7 +40,7 @@ public class RequestHeaderData implements HandlerInterceptor {
         initialiseCorrelationId(request);
         initialiseUserName(request);
         MDC.put("userHost", request.getRemoteHost());
-
+        MDC.put("thread_id", String.valueOf(Thread.currentThread().getId()));
         return true;
     }
 


### PR DESCRIPTION
Made it so all logs will contain a thread_id entry with the thread number of the current thread.