### PR TITLE
Ee 10256/log fail duration

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
@@ -75,7 +75,7 @@ class HmrcResource {
 
         log.info("Income summary successfully retrieved from HMRC",
                 value(EVENT, HMRC_SERVICE_RESPONSE_SUCCESS),
-                value("request_duration", duration)
+                value("request_duration_ms", duration)
                 );
 
         return incomeSummary;

--- a/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
@@ -7,7 +7,6 @@ import uk.gov.digital.ho.pttg.application.NinoUtils;
 import uk.gov.digital.ho.pttg.application.domain.IncomeSummary;
 import uk.gov.digital.ho.pttg.application.domain.Individual;
 
-import java.time.Instant;
 import java.time.LocalDate;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
@@ -20,10 +19,12 @@ class HmrcResource {
 
     private final IncomeSummaryService incomeSummaryService;
     private final NinoUtils ninoUtils;
+    private final RequestHeaderData requestHeaderData;
 
-    HmrcResource(IncomeSummaryService incomeSummaryService, NinoUtils ninoUtils) {
+    HmrcResource(IncomeSummaryService incomeSummaryService, NinoUtils ninoUtils, RequestHeaderData requestHeaderData) {
         this.incomeSummaryService = incomeSummaryService;
         this.ninoUtils = ninoUtils;
+        this.requestHeaderData = requestHeaderData;
     }
 
     @SuppressWarnings("checkstyle:parameternumber")
@@ -65,17 +66,13 @@ class HmrcResource {
 
     private IncomeSummary produceIncomeSummary(Individual individual, LocalDate fromDate, LocalDate toDate) {
 
-        long requestReceived = Instant.now().toEpochMilli();
-
         log.info("Hmrc service invoked for nino {} with date range {} to {}", individual.getNino(), fromDate, toDate, value(EVENT, HMRC_SERVICE_REQUEST_RECEIVED));
 
         IncomeSummary incomeSummary = incomeSummaryService.getIncomeSummary(individual, fromDate, toDate);
 
-        long duration = Instant.now().toEpochMilli() - requestReceived;
-
         log.info("Income summary successfully retrieved from HMRC",
                 value(EVENT, HMRC_SERVICE_RESPONSE_SUCCESS),
-                value("request_duration_ms", duration)
+                value("request_duration_ms", requestHeaderData.calculateRequestDuration())
                 );
 
         return incomeSummary;

--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.UUID;
 
@@ -25,6 +26,7 @@ public class RequestHeaderData implements HandlerInterceptor {
     public static final String SESSION_ID_HEADER = "x-session-id";
     public static final String CORRELATION_ID_HEADER = "x-correlation-id";
     public static final String USER_ID_HEADER = "x-auth-userid";
+    private static final String REQUEST_START_TIMESTAMP = "request-timestamp";
 
     @Value("${auditing.deployment.name}") private String deploymentName;
     @Value("${auditing.deployment.namespace}") private String deploymentNamespace;
@@ -39,6 +41,7 @@ public class RequestHeaderData implements HandlerInterceptor {
         initialiseSessionId(request);
         initialiseCorrelationId(request);
         initialiseUserName(request);
+        inititaliseRequestStart();
         MDC.put("userHost", request.getRemoteHost());
 
         return true;
@@ -83,6 +86,17 @@ public class RequestHeaderData implements HandlerInterceptor {
         MDC.put(USER_ID_HEADER, userId);
     }
 
+    private void inititaliseRequestStart() {
+        long requestStartTimeStamp = Instant.now().toEpochMilli();
+        MDC.put(REQUEST_START_TIMESTAMP, Long.toString(requestStartTimeStamp));
+
+    }
+
+    long calculateRequestDuration() {
+        long timeStamp = Instant.now().toEpochMilli();
+        return timeStamp - Long.parseLong(MDC.get(REQUEST_START_TIMESTAMP));
+    }
+
     public String deploymentName() {
         return deploymentName;
     }
@@ -110,4 +124,5 @@ public class RequestHeaderData implements HandlerInterceptor {
     public String userId() {
         return MDC.get(USER_ID_HEADER);
     }
+
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceDeprecatedGetTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceDeprecatedGetTest.java
@@ -38,13 +38,14 @@ public class HmrcResourceDeprecatedGetTest {
     @Mock private IncomeSummaryService mockIncomeSummaryService;
     @Mock private NinoUtils mockNinoUtils;
     @Mock private IncomeSummary mockIncomeSummary;
+    @Mock private RequestHeaderData mockRequestHeaderData;
     @Mock private Appender<ILoggingEvent> mockAppender;
 
     private HmrcResource hmrcResource;
 
     @Before
     public void setup() {
-        hmrcResource = new HmrcResource(mockIncomeSummaryService, mockNinoUtils);
+        hmrcResource = new HmrcResource(mockIncomeSummaryService, mockNinoUtils, mockRequestHeaderData);
         when(mockIncomeSummaryService.getIncomeSummary(isA(Individual.class), eq(FROM_DATE), eq(TO_DATE))).thenReturn(mockIncomeSummary);
         when(mockNinoUtils.sanitise(NINO)).thenReturn(NINO);
 

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceTest.java
@@ -41,6 +41,7 @@ public class HmrcResourceTest {
     @Mock private IncomeSummaryService mockIncomeSummaryService;
     @Mock private NinoUtils mockNinoUtils;
     @Mock private IncomeSummary mockIncomeSummary;
+    @Mock private RequestHeaderData mockRequestHeaderData;
     @Mock private Appender<ILoggingEvent> mockAppender;
 
     @Captor private ArgumentCaptor<Individual> captorIndividual;
@@ -49,7 +50,7 @@ public class HmrcResourceTest {
 
     @Before
     public void setup() {
-        hmrcResource = new HmrcResource(mockIncomeSummaryService, mockNinoUtils);
+        hmrcResource = new HmrcResource(mockIncomeSummaryService, mockNinoUtils, mockRequestHeaderData);
         when(mockIncomeSummaryService.getIncomeSummary(eq(new Individual(FIRST_NAME, LAST_NAME, NINO, DATE_OF_BIRTH, ALIAS_SURNAMES)), eq(FROM_DATE), eq(TO_DATE))).thenReturn(mockIncomeSummary);
         when(mockNinoUtils.sanitise(NINO)).thenReturn(NINO);
 
@@ -65,6 +66,7 @@ public class HmrcResourceTest {
 
         verify(mockNinoUtils).sanitise(NINO);
         verify(mockIncomeSummaryService).getIncomeSummary(captorIndividual.capture(), eq(FROM_DATE), eq(TO_DATE));
+        verify(mockRequestHeaderData).calculateRequestDuration();
 
         assertThat(captorIndividual.getValue().getFirstName()).isEqualTo(FIRST_NAME);
         assertThat(captorIndividual.getValue().getLastName()).isEqualTo(LAST_NAME);

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceTest.java
@@ -103,7 +103,7 @@ public class HmrcResourceTest {
 
             return loggingEvent.getFormattedMessage().equals("Income summary successfully retrieved from HMRC") &&
                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[0]).getFieldName().equals("event_id") &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration");
+                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
         }));
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/RequestHeaderDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/RequestHeaderDataTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -98,5 +99,17 @@ public class RequestHeaderDataTest {
             return loggingEvent.getFormattedMessage().equals("Generated new correlation id as not passed in request header") &&
                     loggingEvent.getArgumentArray()[0].equals(new ObjectAppendingMarker("event_id", HMRC_SERVICE_GENERATED_CORRELATION_ID));
         }));
+    }
+
+    @Test
+    public void shouldAddRequestTimeStampToMDC() {
+        requestData.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        assertThat(MDC.get("request-timestamp")).isNotNull();
+    }
+
+    @Test
+    public void shouldReturnRequestDuration() {
+        requestData.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        assertThat(requestData.calculateRequestDuration()).isNotNegative();
     }
 }


### PR DESCRIPTION
This adds milliseconds to the request duration field name and also refactors the request duration calculation moving it to the MDC.