### PR TITLE
EE-10292 Fixed resolution of the access-code URI 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcAccessCodeClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcAccessCodeClient.java
@@ -51,7 +51,7 @@ public class HmrcAccessCodeClient {
                                 @Value("${hmrc.access.service.retry.delay}") long retryDelayInMillis) {
         this.restTemplate = restTemplate;
         this.baseAccessCodeUrl = baseAccessCodeUrl;
-        this.accessUri = URI.create(baseAccessCodeUrl).resolve(ACCESS_ENDPOINT_PATH);
+        this.accessUri = URI.create(baseAccessCodeUrl + ACCESS_ENDPOINT_PATH);
         this.requestHeaderData = requestHeaderData;
 
         this.maxRetryAttempts = maxRetryAttempts;

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcAccessCodeClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcAccessCodeClientTest.java
@@ -29,6 +29,7 @@ import uk.gov.digital.ho.pttg.dto.AccessCode;
 import java.net.ConnectException;
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -328,6 +329,31 @@ public class HmrcAccessCodeClientTest {
 
         verify(mockRestTemplate).postForLocation(uriCaptor.capture(), any(HttpEntity.class));
         assertThat(uriCaptor.getValue().getPath()).contains("123");
+    }
+
+    @Test
+    public void accessCodeUri_noPathOnBaseUri_shouldResolve() {
+        String baseAccessCodeUrl = "https://eue-api-hmrc-access-code.dev-i-cust-pt.svc.cluster.local";
+
+        HmrcAccessCodeClient client = new HmrcAccessCodeClient(mockRestTemplate, mockRequestHeaderData, baseAccessCodeUrl, MAX_RETRY_ATTEMPTS, RETRY_DELAY_IN_MILLIS);
+
+        URI accessUri = (URI) ReflectionTestUtils.getField(client, "accessUri");
+        assertThat(accessUri).isNotNull();
+
+        assertThat(accessUri.toString()).isEqualTo("https://eue-api-hmrc-access-code.dev-i-cust-pt.svc.cluster.local/access");
+    }
+
+    @Test
+    public void accessCodeUri_pathOnBaseUri_shouldResolve() {
+        String baseAccessCodeUrl = "http://localhost:10080/hmrcaccesscode";
+
+        HmrcAccessCodeClient client = new HmrcAccessCodeClient(mockRestTemplate, mockRequestHeaderData, baseAccessCodeUrl, MAX_RETRY_ATTEMPTS, RETRY_DELAY_IN_MILLIS);
+
+        URI accessUri = (URI) ReflectionTestUtils.getField(client, "accessUri");
+        assertThat(accessUri).isNotNull();
+
+
+        assertThat(accessUri.toString()).isEqualTo("http://localhost:10080/hmrcaccesscode/access");
     }
 
     private ResourceAccessException connectionRefusedException(final String exceptionMessage) {


### PR DESCRIPTION
Despite changing the URL for the hmrc-access-code service in the helm-chart, I was still getting basic auth errors. And the URL being called seemed to ignore the /hmrcaccesscode bit put in to send the request through the proxy.

The reason was that the line URI.create(baseAccessCodeUrl).resolve(ACCESS_ENDPOINT_PATH) works fine for baseAccessCodeUrl="http://localhost:10080" and ACCESS_ENDPOINT_PATH="/accesscode" resulting in "http://localhost:10080/accesscode"

However, when  baseAccessCodeUrl="http://localhost:10080/hmrcaccesscode" and  ACCESS_ENDPOINT_PATH="/accesscode", the result is still "http://localhost:10080/accesscode"! Must be some funny URI resolution rule!