### PR TITLE
EE-10920: add pool size to logs

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.digital.ho.pttg.api.RequestHeaderData.POOL_SIZE;
 import static uk.gov.digital.ho.pttg.api.RequestHeaderData.REQUEST_DURATION_MS;
 import static uk.gov.digital.ho.pttg.application.LogEvent.*;
 
@@ -73,7 +74,8 @@ class HmrcResource {
 
         log.info("Income summary successfully retrieved from HMRC",
                 value(EVENT, HMRC_SERVICE_RESPONSE_SUCCESS),
-                value(REQUEST_DURATION_MS, requestHeaderData.calculateRequestDuration())
+                value(REQUEST_DURATION_MS, requestHeaderData.calculateRequestDuration()),
+                value(POOL_SIZE, requestHeaderData.poolSize())
                 );
 
         return incomeSummary;

--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -28,6 +29,7 @@ public class RequestHeaderData implements HandlerInterceptor {
     private static final String REQUEST_START_TIMESTAMP = "request-timestamp";
     public static final String REQUEST_DURATION_MS = "request_duration_ms";
     public static final String THREAD_COUNT = "thread_count";
+    public static final String POOL_SIZE = "pool_size";
 
     @Value("${auditing.deployment.name}") private String deploymentName;
     @Value("${auditing.deployment.namespace}") private String deploymentNamespace;
@@ -106,6 +108,8 @@ public class RequestHeaderData implements HandlerInterceptor {
     private void initialiseThreadCount() {
         MDC.put(THREAD_COUNT, Integer.toString(activeCount()));
     }
+
+    Integer poolSize() { return new ThreadPoolTaskExecutor().getPoolSize(); }
 
     public String deploymentNamespace() {
         return deploymentNamespace;


### PR DESCRIPTION
In an effort to evaluate what is happening to the service under stress it was decided to add more logging in the output. 
This is to add a pool size to the output of a successful HMRC service request.