### PR TITLE
Ee 12943 chart version timing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ pipeline:
       event: [push, pull_request, tag]
 
   update-version:
-    image: quay.io/ukhomeofficedigital/docker-openjdk8-git:v1.3
+    image: quay.io/ukhomeofficedigital/docker-openjdk8-git:v1.3.1
     secrets:
       - github_ssh_key
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ pipeline:
       - github_ssh_key
     commands:
       - sh /root/git-utilities/set-up-github-user.sh "$${GITHUB_SSH_KEY}"
-      - sh /root/gradle-utilities/update-project-version.sh
+      - ./gradlew release -Prelease.useAutomaticVersion=true -x runBuildTasks
     when:
       branch: [master ]
       event: [push]

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 name: eue-api-hmrc-service
 version: 0.1.0
-appVersion: ''
+appVersion: '1.0.3'

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 name: eue-api-hmrc-service
 version: 0.1.0
-appVersion: ''
+appVersion: '1.0.0'

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 name: eue-api-hmrc-service
 version: 0.1.0
-appVersion: '0.0.1'
+appVersion: '1.0.0'

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 name: eue-api-hmrc-service
 version: 0.1.0
-appVersion: '1.0.0'
+appVersion: ''

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,3 @@
 name: eue-api-hmrc-service
 version: 0.1.0
-appVersion: '1.0.3'
+appVersion: '1.0.4'

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ void updateChart_steps() {
     commandLine 'sh', '-c', 'set -x && NEW_VERSION=$(git describe --abbrev=0)'
   }
   exec {
-    commandLine 'sh', '-c', 'set -x && echo "release.newVersion=${release.newVersion}"'
+    commandLine 'sh', '-c', 'set -x && echo "release.newVersion="' + release.newVersion
   }
   exec {
     commandLine 'sh', '-c', 'set -x && sed "/appVersion/c\\\\appVersion: \'${NEW_VERSION}\'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml'

--- a/build.gradle
+++ b/build.gradle
@@ -161,15 +161,6 @@ tasks.preTagCommit.dependsOn updateChart
 
 void updateChart_steps() {
   exec {
-    commandLine 'sh', '-c', 'set -x && NEW_VERSION=$(git describe --abbrev=0)'
-  }
-  exec {
-    commandLine 'sh', '-c', 'set -x && echo "release.newVersion="' + release.newVersion
-  }
-  exec {
-    commandLine 'sh', '-c', 'set -x && sed "/appVersion/c\\\\appVersion: \'${NEW_VERSION}\'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml'
-  }
-  exec {
-    commandLine 'sh', '-c', 'set -x && git add Chart.yaml'
+    commandLine 'sh', '-c', 'sh update-chart.sh'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -161,15 +161,15 @@ tasks.preTagCommit.dependsOn updateChart
 
 void updateChart_steps() {
   exec {
-    commandLine 'sh', '-c', 'NEW_VERSION=$(git describe --abbrev=0)'
+    commandLine 'sh', '-c', 'set -x && NEW_VERSION=$(git describe --abbrev=0)'
   }
   exec {
-    commandLine 'sh', '-c', 'echo ${NEW_VERSION}'
+    commandLine 'sh', '-c', 'set -x && echo "NEW_VERSION=${NEW_VERSION}"'
   }
   exec {
-    commandLine 'sh', '-c', 'sed "/appVersion/c\\\\appVersion: \'${NEW_VERSION}\'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml'
+    commandLine 'sh', '-c', 'set -x && sed "/appVersion/c\\\\appVersion: \'${NEW_VERSION}\'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml'
   }
   exec {
-    commandLine 'sh', '-c', 'git add Chart.yaml'
+    commandLine 'sh', '-c', 'set -x && git add Chart.yaml'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ void updateChart_steps() {
     commandLine 'sh', '-c', 'set -x && NEW_VERSION=$(git describe --abbrev=0)'
   }
   exec {
-    commandLine 'sh', '-c', 'set -x && echo "NEW_VERSION=${NEW_VERSION}"'
+    commandLine 'sh', '-c', 'set -x && echo "release.newVersion=${release.newVersion}"'
   }
   exec {
     commandLine 'sh', '-c', 'set -x && sed "/appVersion/c\\\\appVersion: \'${NEW_VERSION}\'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml'

--- a/build.gradle
+++ b/build.gradle
@@ -137,14 +137,39 @@ dependencies {
 gradle.startParameter.continueOnFailure = false
 
 release {
+    git {
+        requireBranch = 'EE-12943-chart-version-timing'
+    }
     preTagCommitMessage = '[Gradle Release Plugin] (EE-9726) [CI SKIP] - pre tag commit: '
     tagCommitMessage = '[Gradle Release Plugin] (EE-9726) - creating tag: '
     newVersionCommitMessage = '[Gradle Release Plugin] (EE-9726) [CI SKIP] - new version commit: '
 }
 
-task setChartVersion(type:Exec) {
-  commandLine 'sh', '-c', 'NEW_VERSION=$(git describe --abbrev=0)'
-  commandLine 'sh', '-c', 'echo ${newVersion}'
-  commandLine 'sh', '-c', 'sed "/appVersion/c\\\\appVersion: \'${NEW_VERSION}\'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml'
-  commandLine 'sh', '-c', 'git add . && git commit -m "Set chart version to ${NEW_VERSION} [CI SKIP]" && git push'
+task updateChart() {
+  doLast {
+    updateChart_steps()
+  }
+}
+
+task testVersion() {
+  exec {
+    commandLine 'sh', '-c', 'echo "version=${version}"'
+  }
+}
+
+tasks.preTagCommit.dependsOn testVersion
+
+void updateChart_steps() {
+  exec {
+    commandLine 'sh', '-c', 'NEW_VERSION=$(git describe --abbrev=0)'
+  }
+  exec {
+    commandLine 'sh', '-c', 'echo ${NEW_VERSION}'
+  }
+  exec {
+    commandLine 'sh', '-c', 'sed "/appVersion/c\\\\appVersion: \'${NEW_VERSION}\'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml'
+  }
+  exec {
+    commandLine 'sh', '-c', 'git add Chart.yaml'
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ task testVersion() {
   }
 }
 
-tasks.preTagCommit.dependsOn testVersion
+tasks.preTagCommit.dependsOn updateChart
 
 void updateChart_steps() {
   exec {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.3
+version=1.0.4-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2-SNAPSHOT
+version=1.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.4-SNAPSHOT
+version=1.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.1
+version=1.0.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.1-SNAPSHOT
+version=1.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.0.3-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.4
+version=1.0.5-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.3-SNAPSHOT
+version=1.0.3

--- a/update-chart.sh
+++ b/update-chart.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+NEW_VERSION=$(sed -e 's/^version=//' -e 's/-SNAPSHOT//' gradle.properties)
+sed "/appVersion/c\\appVersion: '$NEW_VERSION'" Chart.yaml > tempChart.yaml && mv tempChart.yaml Chart.yaml
+git add Chart.yaml


### PR DESCRIPTION
We cannot update the helm chart version number after the commit and tag for the new version - otherwise the chart will always be a version behind.
Instead, hook into the gradle release plugin to update the chart prior to the version number commit.