### PR TITLE
Ee 10741: Handle apostrophe+space like full stop+space in HMRC name matching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
   dependencies {
     classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     classpath 'net.researchgate:gradle-release:2.6.0'
+    classpath 'net.serenity-bdd:serenity-gradle-plugin:2.0.38'
   }
 }
 
@@ -35,6 +36,7 @@ apply plugin: 'findbugs'
 apply plugin: 'jacoco'
 apply plugin: 'project-report'
 apply plugin: 'net.researchgate.release'
+apply plugin: 'net.serenity-bdd.aggregator'
 
 checkstyleTest.enabled = false
 checkstyle {
@@ -117,8 +119,8 @@ dependencies {
   testCompile group: 'cglib', name: 'cglib-nodep', version: '3.2.5'
   testCompile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.9.3'
 
-  testCompile group: 'net.serenity-bdd', name: 'serenity-cucumber', version: '1.9.18'
-  testCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '2.0.7'
+  testCompile group: 'net.serenity-bdd', name: 'serenity-cucumber', version: '1.9.29'
+  testCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '2.0.38'
 
   testCompile group: 'info.cukes', name:'gherkin', version: '2.12.2'
 
@@ -133,6 +135,14 @@ dependencies {
 
 }
 
+task testCucumber(type: Test) {
+  include 'bdd/ExecutableSpecifications*'
+  finalizedBy aggregate
+  testLogging.showStandardStreams = true
+  outputs.upToDateWhen { false }
+}
+
+build.dependsOn(testCucumber)
 
 gradle.startParameter.continueOnFailure = false
 

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctions.java
@@ -12,35 +12,26 @@ import static java.util.Collections.emptyList;
 public final class AbbreviatedNamesFunctions {
 
     private static final String ANY_LETTER_INCLUDING_UNICODE_MATCHER = "\\p{L}\\p{M}*+";
-    private static final String FULL_STOP_SPACE_MATCHER = "\\.\\s+";
-    private static final String APOSTROPHE_SPACE_MATCHER = "\'\\s+";
+    private static final String ABBREVIATION_SPACE_MATCHER = "([.'])\\s+";
 
-    private static final String FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + FULL_STOP_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
-    private static final String APOSTROPHE_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + APOSTROPHE_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
-
-    private static final Pattern FULL_STOP_SPACE_PATTERN_REGEX = Pattern.compile(FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN);
-    private static final Pattern APOSTROPHE_SPACE_PATTERN_REGEX = Pattern.compile(APOSTROPHE_SPACE_BETWEEN_NAMES_PATTERN);
+    private static final String ABBREVIATION_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + ABBREVIATION_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
+    private static final Pattern ABBREVIATION_SPACE_REGEX_PATTERN = Pattern.compile(ABBREVIATION_SPACE_BETWEEN_NAMES_PATTERN);
 
     private static final String ABBREVIATION_SPACE_NEGATIVE_LOOK_BEHIND = "(?<!(\\.|'|\\s))";
     private static final String SPACE_NOT_PRECEDED_BY_ABBREVIATION_OR_SPACE_PATTERN = ABBREVIATION_SPACE_NEGATIVE_LOOK_BEHIND + "\\s+";
 
     static boolean doesNotContainAbbreviatedNames(InputNames inputNames) {
-        if (nameDoesContainAbbreviationSpaceBetweenNames(inputNames.fullFirstName())) {
+        if (nameContainsAbbreviationSpaceBetweenNames(inputNames.fullFirstName())) {
             return false;
         }
-        if (nameDoesContainAbbreviationSpaceBetweenNames(inputNames.fullLastName())) {
+        if (nameContainsAbbreviationSpaceBetweenNames(inputNames.fullLastName())) {
             return false;
         }
-        return !nameDoesContainAbbreviationSpaceBetweenNames(inputNames.fullAliasNames());
+        return !nameContainsAbbreviationSpaceBetweenNames(inputNames.fullAliasNames());
     }
 
-    private static boolean nameDoesContainAbbreviationSpaceBetweenNames(String name) {
-
-        if (FULL_STOP_SPACE_PATTERN_REGEX.matcher(name).find()) {
-            return true;
-        }
-
-        return APOSTROPHE_SPACE_PATTERN_REGEX.matcher(name).find();
+    private static boolean nameContainsAbbreviationSpaceBetweenNames(String name) {
+        return ABBREVIATION_SPACE_REGEX_PATTERN.matcher(name).find();
     }
 
     public static List<String> splitAroundAbbreviatedNames(String names) {

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctions.java
@@ -12,7 +12,7 @@ import static java.util.Collections.emptyList;
 public final class AbbreviatedNamesFunctions {
 
     private static final String ANY_LETTER_INCLUDING_UNICODE_MATCHER = "\\p{L}\\p{M}*+";
-    private static final String ABBREVIATION_SPACE_MATCHER = "([.'])\\s+";
+    private static final String ABBREVIATION_SPACE_MATCHER = "[.']\\s+";
 
     private static final String ABBREVIATION_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + ABBREVIATION_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
     private static final Pattern ABBREVIATION_SPACE_REGEX_PATTERN = Pattern.compile(ABBREVIATION_SPACE_BETWEEN_NAMES_PATTERN);

--- a/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctions.java
@@ -13,24 +13,34 @@ public final class AbbreviatedNamesFunctions {
 
     private static final String ANY_LETTER_INCLUDING_UNICODE_MATCHER = "\\p{L}\\p{M}*+";
     private static final String FULL_STOP_SPACE_MATCHER = "\\.\\s+";
-    private static final String FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + FULL_STOP_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
-    private static final Pattern FULL_STOP_SPACE_PATTERN_REGEX = Pattern.compile(FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN);
+    private static final String APOSTROPHE_SPACE_MATCHER = "\'\\s+";
 
-    private static final String FULL_STOP_SPACE_NEGATIVE_LOOK_BEHIND = "(?<!(\\.|\\s))";
-    private static final String SPACE_NOT_PRECEDED_BY_FULL_STOP_OR_SPACE_PATTERN = FULL_STOP_SPACE_NEGATIVE_LOOK_BEHIND + "\\s+";
+    private static final String FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + FULL_STOP_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
+    private static final String APOSTROPHE_SPACE_BETWEEN_NAMES_PATTERN = ANY_LETTER_INCLUDING_UNICODE_MATCHER + APOSTROPHE_SPACE_MATCHER + ANY_LETTER_INCLUDING_UNICODE_MATCHER;
+
+    private static final Pattern FULL_STOP_SPACE_PATTERN_REGEX = Pattern.compile(FULL_STOP_SPACE_BETWEEN_NAMES_PATTERN);
+    private static final Pattern APOSTROPHE_SPACE_PATTERN_REGEX = Pattern.compile(APOSTROPHE_SPACE_BETWEEN_NAMES_PATTERN);
+
+    private static final String ABBREVIATION_SPACE_NEGATIVE_LOOK_BEHIND = "(?<!(\\.|'|\\s))";
+    private static final String SPACE_NOT_PRECEDED_BY_ABBREVIATION_OR_SPACE_PATTERN = ABBREVIATION_SPACE_NEGATIVE_LOOK_BEHIND + "\\s+";
 
     static boolean doesNotContainAbbreviatedNames(InputNames inputNames) {
-        if (nameContainsFullStopSpaceBetweenNames(inputNames.fullFirstName())) {
+        if (nameDoesContainAbbreviationSpaceBetweenNames(inputNames.fullFirstName())) {
             return false;
         }
-        if (nameContainsFullStopSpaceBetweenNames(inputNames.fullLastName())) {
+        if (nameDoesContainAbbreviationSpaceBetweenNames(inputNames.fullLastName())) {
             return false;
         }
-        return !nameContainsFullStopSpaceBetweenNames(inputNames.fullAliasNames());
+        return !nameDoesContainAbbreviationSpaceBetweenNames(inputNames.fullAliasNames());
     }
 
-    private static boolean nameContainsFullStopSpaceBetweenNames(String name) {
-        return FULL_STOP_SPACE_PATTERN_REGEX.matcher(name).find();
+    private static boolean nameDoesContainAbbreviationSpaceBetweenNames(String name) {
+
+        if (FULL_STOP_SPACE_PATTERN_REGEX.matcher(name).find()) {
+            return true;
+        }
+
+        return APOSTROPHE_SPACE_PATTERN_REGEX.matcher(name).find();
     }
 
     public static List<String> splitAroundAbbreviatedNames(String names) {
@@ -39,7 +49,7 @@ public final class AbbreviatedNamesFunctions {
             return emptyList();
         }
 
-        String[] splitNames = names.split(SPACE_NOT_PRECEDED_BY_FULL_STOP_OR_SPACE_PATTERN);
+        String[] splitNames = names.split(SPACE_NOT_PRECEDED_BY_ABBREVIATION_OR_SPACE_PATTERN);
 
         return Arrays.stream(splitNames)
                 .map(AbbreviatedNamesFunctions::removeMultipleSpaces)

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctionsDoesNotContainAbbreviatedNamesTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctionsDoesNotContainAbbreviatedNamesTest.java
@@ -6,7 +6,7 @@ import uk.gov.digital.ho.pttg.application.namematching.InputNames;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.AbbreviatedNamesFunctions.doesNotContainAbbreviatedNames;
 
-public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest {
+public class AbbreviatedNamesFunctionsDoesNotContainAbbreviatedNamesTest {
 
     @Test
     public void doesNotContainAbbreviatedNames_emptyString_returnTrue() {

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctionsSplitAroundAbbreviatedNamesTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/AbbreviatedNamesFunctionsSplitAroundAbbreviatedNamesTest.java
@@ -9,7 +9,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.AbbreviatedNamesFunctions.splitAroundAbbreviatedNames;
 
-public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
+public class AbbreviatedNamesFunctionsSplitAroundAbbreviatedNamesTest {
 
     @Test
     public void splitAroundAbbreviatedNames_emptyName_returnEmptyList() {

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest.java
@@ -9,115 +9,115 @@ import static uk.gov.digital.ho.pttg.application.namematching.candidates.Abbrevi
 public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest {
 
     @Test
-    public void doesNotContainAbbreviationSpaceBetweenNames_emptyString_returnTrue() {
+    public void doesNotContainAbbreviatedNames_emptyString_returnTrue() {
         InputNames emptyStringNames = new InputNames("", "");
         assertThat(doesNotContainAbbreviatedNames(emptyStringNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_fullStopOnly_returnTrue() {
+    public void doesNotContainAbbreviatedNames_fullStopOnly_returnTrue() {
         InputNames fullStopOnlyNames = new InputNames(".", ".");
         assertThat(doesNotContainAbbreviatedNames(fullStopOnlyNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_apostropheOnly_returnTrue() {
+    public void doesNotContainAbbreviatedNames_apostropheOnly_returnTrue() {
         InputNames apostropheOnlyNames = new InputNames("'", "'");
         assertThat(doesNotContainAbbreviatedNames(apostropheOnlyNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainAbbreviationSpaceBetweenNames_spaceOnly_returnTrue() {
+    public void doesNotContainAbbreviatedNames_spaceOnly_returnTrue() {
         InputNames spaceOnlyNames = new InputNames(" ", " ");
         assertThat(doesNotContainAbbreviatedNames(spaceOnlyNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceNoLetters_returnTrue() {
+    public void doesNotContainAbbreviatedNames_fullStopSpaceNoLetters_returnTrue() {
         InputNames fullStopSpaceOnlyNames = new InputNames(". ", ". ");
         assertThat(doesNotContainAbbreviatedNames(fullStopSpaceOnlyNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_fullStopSpaceNoLetters_returnTrue() {
+    public void doesNotContainAbbreviatedNames_apostropheSpaceNoLetters_returnTrue() {
         InputNames apostropheSpaceOnlyNames = new InputNames("' ", "' ");
         assertThat(doesNotContainAbbreviatedNames(apostropheSpaceOnlyNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_noNameAfterSpace_returnTrue() {
+    public void doesNotContainAbbreviatedNames_nameFullStopSpaceNoName_returnTrue() {
         InputNames noNameAfterSpaceNames = new InputNames("St. ", "St. ");
         assertThat(doesNotContainAbbreviatedNames(noNameAfterSpaceNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_noNameAfterSpace_returnTrue() {
+    public void doesNotContainAbbreviatedNames_nameApostropheSpaceNoName_returnTrue() {
         InputNames noNameAfterSpaceNames = new InputNames("O' ", "O' ");
         assertThat(doesNotContainAbbreviatedNames(noNameAfterSpaceNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_noNameBeforeFullStop_returnTrue() {
+    public void doesNotContainAbbreviatedNames_noNameBeforeFullStop_returnTrue() {
         InputNames noNameBeforeFullStopNames = new InputNames(". John", ". John");
         assertThat(doesNotContainAbbreviatedNames(noNameBeforeFullStopNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_noNameBeforeApostrophe_returnTrue() {
+    public void doesNotContainAbbreviatedNames_noNameBeforeApostrophe_returnTrue() {
         InputNames noNameBeforeApostropheNames = new InputNames("' Connor", "' Connor");
         assertThat(doesNotContainAbbreviatedNames(noNameBeforeApostropheNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceFirstName_returnFalse() {
+    public void doesNotContainAbbreviatedNames_nameFullStopSpaceFirstName_returnFalse() {
         InputNames namesWithFullStopSpaceFirstName = new InputNames("St. John", "Smith");
         assertThat(doesNotContainAbbreviatedNames(namesWithFullStopSpaceFirstName)).isFalse();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_apostropheSpaceFirstName_returnFalse() {
+    public void doesNotContainAbbreviatedNames_nameApostropheSpaceFirstName_returnFalse() {
         InputNames namesWithApostropheSpaceFirstName = new InputNames("O' Connor", "John");
         assertThat(doesNotContainAbbreviatedNames(namesWithApostropheSpaceFirstName)).isFalse();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceLastName_returnFalse() {
+    public void doesNotContainAbbreviatedNames_nameFullStopSpaceLastName_returnFalse() {
         InputNames namesWithFullStopSpaceLastName = new InputNames("David", "St. John");
         assertThat(doesNotContainAbbreviatedNames(namesWithFullStopSpaceLastName)).isFalse();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_apostropheSpaceLastName_returnFalse() {
+    public void doesNotContainAbbreviatedNames_nameApostropheSpaceLastName_returnFalse() {
         InputNames namesWithApostropheSpaceLastName = new InputNames("David", "O' Connor");
         assertThat(doesNotContainAbbreviatedNames(namesWithApostropheSpaceLastName)).isFalse();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_doubleFullStopNotName_returnTrue() {
+    public void doesNotContainAbbreviatedNames_doubleFullStopNotName_returnTrue() {
         InputNames doubleFullStopNames = new InputNames(".. John", ".. John");
         assertThat(doesNotContainAbbreviatedNames(doubleFullStopNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_doubleApostropheNotName_returnTrue() {
+    public void doesNotContainAbbreviatedNames_doubleApostropheNotName_returnTrue() {
         InputNames doubleApostropheNames = new InputNames("'' Connor", "'' Connor");
         assertThat(doesNotContainAbbreviatedNames(doubleApostropheNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_fullStopAfterSpaceNotName_returnTrue() {
-        InputNames fullStopAfterSpaceNames = new InputNames("St. .","St. .");
+    public void doesNotContainAbbreviatedNames_fullStopAfterSpaceNotName_returnTrue() {
+        InputNames fullStopAfterSpaceNames = new InputNames("St. .", "St. .");
         assertThat(doesNotContainAbbreviatedNames(fullStopAfterSpaceNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_apostropheAfterSpaceNotName_returnTrue() {
-        InputNames apostropheAfterSpaceNames = new InputNames("Da' '","Da' '");
+    public void doesNotContainAbbreviatedNames_apostropheAfterSpaceNotName_returnTrue() {
+        InputNames apostropheAfterSpaceNames = new InputNames("Da' '", "Da' '");
         assertThat(doesNotContainAbbreviatedNames(apostropheAfterSpaceNames)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_accentedCharactersAtBoundary_returnFalse() {
+    public void doesNotContainAbbreviatedNames_accentedCharactersAtBoundary_returnFalse() {
         InputNames accentBeforeFullStop = new InputNames("à. b", "Smith");
         InputNames accentAfterFullStop = new InputNames("David", "b. à");
         assertThat(doesNotContainAbbreviatedNames(accentBeforeFullStop)).isFalse();
@@ -125,21 +125,21 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_aliasWithOutFullstopSpace_returnTrue(){
+    public void doesNotContainAbbreviatedNames_aliasWithOutFullStopSpace_returnTrue(){
         InputNames noFullStopSpace = new InputNames("John", "Smith", "Jones");
 
         assertThat(doesNotContainAbbreviatedNames(noFullStopSpace)).isTrue();
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_aliasWithFullstopSpace_returnFalse(){
+    public void doesNotContainAbbreviatedNames_aliasWithFullStopSpace_returnFalse(){
         InputNames withFullStopSpace = new InputNames("John", "Smith", "St. John");
 
         assertThat(doesNotContainAbbreviatedNames(withFullStopSpace)).isFalse();
     }
 
     @Test
-    public void doesNotContainApostropheSpaceBetweenNames_aliasWithApostropheSpace_returnFalse(){
+    public void doesNotContainAbbreviatedNames_aliasWithApostropheSpace_returnFalse(){
         InputNames withFullStopSpace = new InputNames("John", "Smith", "O' Connor");
 
         assertThat(doesNotContainAbbreviatedNames(withFullStopSpace)).isFalse();

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest.java
@@ -6,10 +6,10 @@ import uk.gov.digital.ho.pttg.application.namematching.InputNames;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.AbbreviatedNamesFunctions.doesNotContainAbbreviatedNames;
 
-public class AbbreviatedAbbreviatedNamesWithFullStopSpaceCombinationsFunctionsContainFullStopSpaceTest {
+public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesFunctionsTest {
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_emptyString_returnTrue() {
+    public void doesNotContainAbbreviationSpaceBetweenNames_emptyString_returnTrue() {
         InputNames emptyStringNames = new InputNames("", "");
         assertThat(doesNotContainAbbreviatedNames(emptyStringNames)).isTrue();
     }
@@ -21,7 +21,13 @@ public class AbbreviatedAbbreviatedNamesWithFullStopSpaceCombinationsFunctionsCo
     }
 
     @Test
-    public void doesNotContainFullStopSpaceBetweenNames_spaceOnly_returnTrue() {
+    public void doesNotContainApostropheSpaceBetweenNames_apostropheOnly_returnTrue() {
+        InputNames apostropheOnlyNames = new InputNames("'", "'");
+        assertThat(doesNotContainAbbreviatedNames(apostropheOnlyNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainAbbreviationSpaceBetweenNames_spaceOnly_returnTrue() {
         InputNames spaceOnlyNames = new InputNames(" ", " ");
         assertThat(doesNotContainAbbreviatedNames(spaceOnlyNames)).isTrue();
     }
@@ -33,8 +39,20 @@ public class AbbreviatedAbbreviatedNamesWithFullStopSpaceCombinationsFunctionsCo
     }
 
     @Test
+    public void doesNotContainApostropheSpaceBetweenNames_fullStopSpaceNoLetters_returnTrue() {
+        InputNames apostropheSpaceOnlyNames = new InputNames("' ", "' ");
+        assertThat(doesNotContainAbbreviatedNames(apostropheSpaceOnlyNames)).isTrue();
+    }
+
+    @Test
     public void doesNotContainFullStopSpaceBetweenNames_noNameAfterSpace_returnTrue() {
         InputNames noNameAfterSpaceNames = new InputNames("St. ", "St. ");
+        assertThat(doesNotContainAbbreviatedNames(noNameAfterSpaceNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainApostropheSpaceBetweenNames_noNameAfterSpace_returnTrue() {
+        InputNames noNameAfterSpaceNames = new InputNames("O' ", "O' ");
         assertThat(doesNotContainAbbreviatedNames(noNameAfterSpaceNames)).isTrue();
     }
 
@@ -45,9 +63,21 @@ public class AbbreviatedAbbreviatedNamesWithFullStopSpaceCombinationsFunctionsCo
     }
 
     @Test
+    public void doesNotContainApostropheSpaceBetweenNames_noNameBeforeApostrophe_returnTrue() {
+        InputNames noNameBeforeApostropheNames = new InputNames("' Connor", "' Connor");
+        assertThat(doesNotContainAbbreviatedNames(noNameBeforeApostropheNames)).isTrue();
+    }
+
+    @Test
     public void doesNotContainFullStopSpaceBetweenNames_fullStopSpaceFirstName_returnFalse() {
         InputNames namesWithFullStopSpaceFirstName = new InputNames("St. John", "Smith");
         assertThat(doesNotContainAbbreviatedNames(namesWithFullStopSpaceFirstName)).isFalse();
+    }
+
+    @Test
+    public void doesNotContainApostropheSpaceBetweenNames_apostropheSpaceFirstName_returnFalse() {
+        InputNames namesWithApostropheSpaceFirstName = new InputNames("O' Connor", "John");
+        assertThat(doesNotContainAbbreviatedNames(namesWithApostropheSpaceFirstName)).isFalse();
     }
 
     @Test
@@ -57,15 +87,33 @@ public class AbbreviatedAbbreviatedNamesWithFullStopSpaceCombinationsFunctionsCo
     }
 
     @Test
+    public void doesNotContainApostropheSpaceBetweenNames_apostropheSpaceLastName_returnFalse() {
+        InputNames namesWithApostropheSpaceLastName = new InputNames("David", "O' Connor");
+        assertThat(doesNotContainAbbreviatedNames(namesWithApostropheSpaceLastName)).isFalse();
+    }
+
+    @Test
     public void doesNotContainFullStopSpaceBetweenNames_doubleFullStopNotName_returnTrue() {
         InputNames doubleFullStopNames = new InputNames(".. John", ".. John");
         assertThat(doesNotContainAbbreviatedNames(doubleFullStopNames)).isTrue();
     }
 
     @Test
+    public void doesNotContainApostropheSpaceBetweenNames_doubleApostropheNotName_returnTrue() {
+        InputNames doubleApostropheNames = new InputNames("'' Connor", "'' Connor");
+        assertThat(doesNotContainAbbreviatedNames(doubleApostropheNames)).isTrue();
+    }
+
+    @Test
     public void doesNotContainFullStopSpaceBetweenNames_fullStopAfterSpaceNotName_returnTrue() {
-        InputNames fullStopAfterSpaceNames = new InputNames("St. .", "St. .");
+        InputNames fullStopAfterSpaceNames = new InputNames("St. .","St. .");
         assertThat(doesNotContainAbbreviatedNames(fullStopAfterSpaceNames)).isTrue();
+    }
+
+    @Test
+    public void doesNotContainApostropheSpaceBetweenNames_apostropheAfterSpaceNotName_returnTrue() {
+        InputNames apostropheAfterSpaceNames = new InputNames("Da' '","Da' '");
+        assertThat(doesNotContainAbbreviatedNames(apostropheAfterSpaceNames)).isTrue();
     }
 
     @Test
@@ -86,6 +134,13 @@ public class AbbreviatedAbbreviatedNamesWithFullStopSpaceCombinationsFunctionsCo
     @Test
     public void doesNotContainFullStopSpaceBetweenNames_aliasWithFullstopSpace_returnFalse(){
         InputNames withFullStopSpace = new InputNames("John", "Smith", "St. John");
+
+        assertThat(doesNotContainAbbreviatedNames(withFullStopSpace)).isFalse();
+    }
+
+    @Test
+    public void doesNotContainApostropheSpaceBetweenNames_aliasWithApostropheSpace_returnFalse(){
+        InputNames withFullStopSpace = new InputNames("John", "Smith", "O' Connor");
 
         assertThat(doesNotContainAbbreviatedNames(withFullStopSpace)).isFalse();
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest.java
@@ -9,15 +9,15 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.digital.ho.pttg.application.namematching.candidates.AbbreviatedNamesFunctions.splitAroundAbbreviatedNames;
 
-public class NamesWithFullStopSpaceCombinationsFunctionsSplitAbbreviatedAbbreviatedNamesTest {
+public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
 
     @Test
-    public void splitNamesIgnoringFullStopSpace_emptyName_returnEmptyList() {
+    public void splitNamesIgnoringAbbreviationSpace_emptyName_returnEmptyList() {
         assertThat(splitAroundAbbreviatedNames("")).isEmpty();
     }
 
     @Test
-    public void splitNamesIgnoringFullStopSpace_twoNames_returnAsList() {
+    public void splitNamesIgnoringAbbreviationSpace_twoNames_returnAsList() {
         String twoNames = "John Smith";
         List<String> expected = asList("John", "Smith");
 
@@ -56,6 +56,42 @@ public class NamesWithFullStopSpaceCombinationsFunctionsSplitAbbreviatedAbbrevia
     public void splitNamesIgnoringFullStopSpace_tabAfterFullStop_changeToSingleSpace() {
         String nameWithTwoSpaces = "St.\tJohn";
         List<String> expected = singletonList("St. John");
+
+        assertThat(splitAroundAbbreviatedNames(nameWithTwoSpaces))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringApostropheSpace_ApostropheNoSpaceInName_doNotSplit() {
+        String nameWithApostrophe = "O'Connor";
+        List<String> expected = singletonList("O'Connor");
+
+        assertThat(splitAroundAbbreviatedNames(nameWithApostrophe))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringApostropheSpace_ApostropheSpaceInName_doNotSplit() {
+        String nameWithApostrophe = "O' Connor";
+        List<String> expected = singletonList("O' Connor");
+
+        assertThat(splitAroundAbbreviatedNames(nameWithApostrophe))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringApostropheSpace_multipleSpacesAfterApostrophe_reduceToSingleSpace() {
+        String nameWithTwoSpaces = "O'  Connor";
+        List<String> expected = singletonList("O' Connor");
+
+        assertThat(splitAroundAbbreviatedNames(nameWithTwoSpaces))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void splitNamesIgnoringApostropheSpace_tabAfterApostrophe_changeToSingleSpace() {
+        String nameWithTwoSpaces = "O'\tConnor";
+        List<String> expected = singletonList("O' Connor");
 
         assertThat(splitAroundAbbreviatedNames(nameWithTwoSpaces))
                 .isEqualTo(expected);

--- a/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/namematching/candidates/NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest.java
@@ -12,12 +12,12 @@ import static uk.gov.digital.ho.pttg.application.namematching.candidates.Abbrevi
 public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
 
     @Test
-    public void splitNamesIgnoringAbbreviationSpace_emptyName_returnEmptyList() {
+    public void splitAroundAbbreviatedNames_emptyName_returnEmptyList() {
         assertThat(splitAroundAbbreviatedNames("")).isEmpty();
     }
 
     @Test
-    public void splitNamesIgnoringAbbreviationSpace_twoNames_returnAsList() {
+    public void splitAroundAbbreviatedNames_twoNames_returnAsList() {
         String twoNames = "John Smith";
         List<String> expected = asList("John", "Smith");
 
@@ -26,7 +26,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringFullStopSpace_fullStopNoSpaceInName_doNotSplit() {
+    public void splitAroundAbbreviatedNames_fullStopNoSpaceInName_doNotSplit() {
         String nameWithFullStop = "St.John";
         List<String> expected = singletonList("St.John");
 
@@ -35,7 +35,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringFullStopSpace_fullStopSpaceInName_doNotSplit() {
+    public void splitAroundAbbreviatedNames_fullStopSpaceInName_doNotSplit() {
         String nameWithFullStop = "St. John";
         List<String> expected = singletonList("St. John");
 
@@ -44,7 +44,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringFullStopSpace_multipleSpacesAfterFullStop_reduceToSingleSpace() {
+    public void splitAroundAbbreviatedNames_multipleSpacesAfterFullStop_reduceToSingleSpace() {
         String nameWithTwoSpaces = "St.  John";
         List<String> expected = singletonList("St. John");
 
@@ -53,7 +53,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringFullStopSpace_tabAfterFullStop_changeToSingleSpace() {
+    public void splitAroundAbbreviatedNames_tabAfterFullStop_changeToSingleSpace() {
         String nameWithTwoSpaces = "St.\tJohn";
         List<String> expected = singletonList("St. John");
 
@@ -62,7 +62,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringApostropheSpace_ApostropheNoSpaceInName_doNotSplit() {
+    public void splitAroundAbbreviatedNames_apostropheNoSpaceInName_doNotSplit() {
         String nameWithApostrophe = "O'Connor";
         List<String> expected = singletonList("O'Connor");
 
@@ -71,7 +71,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringApostropheSpace_ApostropheSpaceInName_doNotSplit() {
+    public void splitAroundAbbreviatedNames_apostropheSpaceInName_doNotSplit() {
         String nameWithApostrophe = "O' Connor";
         List<String> expected = singletonList("O' Connor");
 
@@ -80,7 +80,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringApostropheSpace_multipleSpacesAfterApostrophe_reduceToSingleSpace() {
+    public void splitAroundAbbreviatedNames_multipleSpacesAfterApostrophe_reduceToSingleSpace() {
         String nameWithTwoSpaces = "O'  Connor";
         List<String> expected = singletonList("O' Connor");
 
@@ -89,7 +89,7 @@ public class NamesWithAbbreviationSpaceCombinationsAbbreviatedNamesTest {
     }
 
     @Test
-    public void splitNamesIgnoringApostropheSpace_tabAfterApostrophe_changeToSingleSpace() {
+    public void splitAroundAbbreviatedNames_tabAfterApostrophe_changeToSingleSpace() {
         String nameWithTwoSpaces = "O'\tConnor";
         List<String> expected = singletonList("O' Connor");
 

--- a/src/test/resources/specs/name-matching/Apostrophe_names.feature
+++ b/src/test/resources/specs/name-matching/Apostrophe_names.feature
@@ -1,4 +1,4 @@
-@Sprint=XX.X
+@Sprint=17.2
 @epic=EE-3855
 @story=Updated_Rules_For_Apostrophe
 @jira=EE-9575
@@ -8,67 +8,70 @@ Feature: Names with apostrophes and spaces
 
   Scenario: Name with a apostrophe and a space which matched with HMRC details
     Given HMRC has the following individual records
-      | First name | Last name | Date of Birth | nino        |
-      | Aaa        | Bb' Ccc   | 1987-12-10    | SE 123456 B |
-    When the applicant submits the following data to the RPS service
-      | First name    | Aaa         |
-      | Last name     | Bb' Ccc     |
-      | Date of Birth | 1987-12-10  |
-      | nino          | SE 123456 B |
-    Then the footprint will try the following combination of names in order
-      | First name | Last name | Date of Birth | nino        |
-      | Aaa        | Bb' Ccc   | 1987-12-10    | SE 123456 B |
+      | First name | Last name | Date of Birth | nino      |
+      | Aaa        | Bb' Ccc   | 1987-12-10    | SE123456B |
+    When an income request is made with the following identity
+      | First name    | Aaa        |
+      | Last name     | Bb' Ccc    |
+      | Date of Birth | 1987-12-10 |
+      | nino          | SE123456B  |
+    Then the following identities will be tried in this order
+      | First name | Last name | Date of Birth | nino      |
+      | Aaa        | Bb' Ccc   | 1987-12-10    | SE123456B |
     And a Matched response will be returned from the service
+    And HMRC was called 1 times
 
 
   Scenario: Enters apostrophe when name does not contain an apostrophe and is matched
     Given HMRC has the following individual records
-      | First name | Last name | Date of Birth | nino        |
-      | Aaa        | Bb Ccc    | 1987-12-10    | SE 123456 B |
-    When the applicant submits the following data to the RPS service
-      | First name    | Aaa         |
-      | Last name     | Bb' Ccc     |
-      | Date of Birth | 1987-12-10  |
-      | nino          | SE 123456 B |
-    Then the footprint will try the following combination of names in order
-      | First name | Last name | Date of Birth | nino        |
-      | Aaa        | Bb' Ccc   | 1987-12-10    | SE 123456 B |
-      | Aaa        | Ccc       | 1987-12-10    | SE 123456 B |
-      | Bb'        | Ccc       | 1987-12-10    | SE 123456 B |
-      | Ccc        | Aaa       | 1987-12-10    | SE 123456 B |
-      | Ccc        | Bb'       | 1987-12-10    | SE 123456 B |
-      | Aaa        | Bb'       | 1987-12-10    | SE 123456 B |
-      | Bb'        | Aaa       | 1987-12-10    | SE 123456 B |
-      | Aaa        | Bb Ccc    | 1987-12-10    | SE 123456 B |
+      | First name | Last name | Date of Birth | nino      |
+      | Aaa        | Bb Ccc    | 1987-12-10    | SE123456B |
+    When an income request is made with the following identity
+      | First name    | Aaa        |
+      | Last name     | Bb' Ccc    |
+      | Date of Birth | 1987-12-10 |
+      | nino          | SE123456B  |
+    Then the following identities will be tried in this order
+      | First name | Last name | Date of Birth | nino      |
+      | Aaa        | Bb' Ccc   | 1987-12-10    | SE123456B |
+      | Aaa        | Ccc       | 1987-12-10    | SE123456B |
+      | Bb'        | Ccc       | 1987-12-10    | SE123456B |
+      | Ccc        | Aaa       | 1987-12-10    | SE123456B |
+      | Ccc        | Bb'       | 1987-12-10    | SE123456B |
+      | Bb'        | Aaa       | 1987-12-10    | SE123456B |
+      | Aaa        | Bb Ccc    | 1987-12-10    | SE123456B |
     And a Matched response will be returned from the service
+    And HMRC was called 7 times
 
 
   Scenario: Name with a apostrophe and no space which matched with HMRC details
     Given HMRC has the following individual records
-      | First name | Last name | Date of Birth | nino        |
-      | Aaa        | Bb'Ccc    | 1987-12-10    | SE 123456 B |
-    When the applicant submits the following data to the RPS service
-      | First name    | Aaa         |
-      | Last name     | Bb'Ccc      |
-      | Date of Birth | 1987-12-10  |
-      | nino          | SE 123456 B |
-    Then the footprint will try the following combination of names in order
-      | First name | Last name | Date of Birth | nino        |
-      | Aaa        | Bb'Ccc    | 1987-12-10    | SE 123456 B |
+      | First name | Last name | Date of Birth | nino      |
+      | Aaa        | Bb'Ccc    | 1987-12-10    | SE123456B |
+    When an income request is made with the following identity
+      | First name    | Aaa        |
+      | Last name     | Bb'Ccc     |
+      | Date of Birth | 1987-12-10 |
+      | nino          | SE123456B  |
+    Then the following identities will be tried in this order
+      | First name | Last name | Date of Birth | nino      |
+      | Aaa        | Bb'Ccc    | 1987-12-10    | SE123456B |
     And a Matched response will be returned from the service
+    And HMRC was called 1 times
 
 
   Scenario: Name when middle name has an apostrophe and a space which is matched with HMRC
     Given HMRC has the following individual records
-      | First name | Last name | Date of Birth | nino        |
-      | Bb' ccc    | Ddd       | 1987-12-10    | SE 123456 B |
-    When the applicant submits the following data to the RPS service
+      | First name | Last name | Date of Birth | nino      |
+      | Bb' ccc    | Ddd       | 1987-12-10    | SE123456B |
+    When an income request is made with the following identity
       | First name    | Aaa Bb' Ccc |
       | Last name     | Ddd         |
       | Date of Birth | 1987-12-10  |
-      | nino          | SE 123456 B |
-    Then the footprint will try the following combination of names in order
-      | First name | Last name | Date of Birth | nino        |
-      | Aaa        | Ddd       | 1987-12-10    | SE 123456 B |
-      | Bb'        | Ddd       | 1987-12-10    | SE 123456 B |
+      | nino          | SE123456B   |
+    Then the following identities will be tried in this order
+      | First name  | Last name | Date of Birth | nino      |
+      | Aaa Bb' Ccc | Ddd       | 1987-12-10    | SE123456B |
+      | Bb'         | Ddd       | 1987-12-10    | SE123456B |
     And a Matched response will be returned from the service
+    And HMRC was called 2 times

--- a/src/test/resources/specs/name-matching/Apostrophe_names.feature
+++ b/src/test/resources/specs/name-matching/Apostrophe_names.feature
@@ -34,11 +34,11 @@ Feature: Names with apostrophes and spaces
     Then the following identities will be tried in this order
       | First name | Last name | Date of Birth | nino      |
       | Aaa        | Bb' Ccc   | 1987-12-10    | SE123456B |
+      | Bb' Ccc    | Aaa       | 1987-12-10    | SE123456B |
       | Aaa        | Ccc       | 1987-12-10    | SE123456B |
       | Bb'        | Ccc       | 1987-12-10    | SE123456B |
       | Ccc        | Aaa       | 1987-12-10    | SE123456B |
       | Ccc        | Bb'       | 1987-12-10    | SE123456B |
-      | Bb'        | Aaa       | 1987-12-10    | SE123456B |
       | Aaa        | Bb Ccc    | 1987-12-10    | SE123456B |
     And a Matched response will be returned from the service
     And HMRC was called 7 times


### PR DESCRIPTION
This is to make HMRC service supply a name which includes an apostrophe followed by a space as it appears instead of stripping the apostrophe out. Much like it currently does with a full stop and space.
Updated unit tests to reflect the changes after adding another REGEX. 