### PR TITLE
Ee 17546 relocate tax year calculation

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -106,9 +106,15 @@ public class HmrcClient {
     }
 
     private void storeSelfAssessmentResource(String accessToken, LocalDate fromDate, LocalDate toDate, IncomeSummaryContext context) {
-        if (context.needsSelfAssessmentResource()) {
-            context.selfAssessmentResource(hateoasClient.getSelfAssessmentResource(accessToken, getTaxYear(fromDate), getTaxYear(toDate), context.getIncomeLink(SELF_ASSESSMENT)));
-        }
+        String toTaxYear = getTaxYear(toDate);
+        String fromTaxYear = getTaxYear(fromDate);
+
+        storeSelfAssessmentResource(accessToken, fromTaxYear, toTaxYear, context);
     }
 
+    private void storeSelfAssessmentResource(String accessToken, String fromTaxYear, String toTaxYear, IncomeSummaryContext context) {
+        if (context.needsSelfAssessmentResource()) {
+            context.selfAssessmentResource(hateoasClient.getSelfAssessmentResource(accessToken, fromTaxYear, toTaxYear, context.getIncomeLink(SELF_ASSESSMENT)));
+        }
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -7,6 +7,8 @@ import uk.gov.digital.ho.pttg.application.domain.Individual;
 
 import java.time.LocalDate;
 
+import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
+
 @Service
 @Slf4j
 public class HmrcClient {
@@ -105,7 +107,7 @@ public class HmrcClient {
 
     private void storeSelfAssessmentResource(String accessToken, LocalDate fromDate, LocalDate toDate, IncomeSummaryContext context) {
         if (context.needsSelfAssessmentResource()) {
-            context.selfAssessmentResource(hateoasClient.getSelfAssessmentResource(accessToken, fromDate, toDate, context.getIncomeLink(SELF_ASSESSMENT)));
+            context.selfAssessmentResource(hateoasClient.getSelfAssessmentResource(accessToken, getTaxYear(fromDate), getTaxYear(toDate), context.getIncomeLink(SELF_ASSESSMENT)));
         }
     }
 

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
@@ -24,5 +24,4 @@ final class HmrcClientFunctions {
     private static int removeFirstTwoDigits(int fourDigitYear) {
         return fourDigitYear % 100;
     }
-
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
@@ -1,0 +1,28 @@
+package uk.gov.digital.ho.pttg.application;
+
+import java.time.LocalDate;
+import java.time.MonthDay;
+
+final class HmrcClientFunctions {
+
+    private HmrcClientFunctions() {
+        throw new UnsupportedOperationException("Companion class for HmrcClient - do not instatiate.");
+    }
+
+    private static final MonthDay END_OF_TAX_YEAR = MonthDay.of(4, 5);
+
+    static String getTaxYear(LocalDate date) {
+        String taxYear;
+        if (MonthDay.from(date).isAfter(END_OF_TAX_YEAR)) {
+            taxYear = date.getYear() + "-" + (removeFirstTwoDigits(date.getYear() + 1));
+        } else {
+            taxYear = (date.getYear() - 1) + "-" + removeFirstTwoDigits(date.getYear());
+        }
+        return taxYear;
+    }
+
+    private static int removeFirstTwoDigits(int fourDigitYear) {
+        return fourDigitYear % 100;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClient.java
@@ -246,29 +246,6 @@ public class HmrcHateoasClient {
         return resource;
     }
 
-    Resource<String> getSelfAssessmentResource(String accessToken, LocalDate fromDate, LocalDate toDate, Link link) {
-
-        if (link == null) {
-            log.debug("No SA Resource");
-            return new Resource<>("", emptyList());
-        }
-
-        String baseUrl = asAbsolute(link.getHref());
-        String url = buildLinkWithTaxYearRangeQueryParams(fromDate, toDate, baseUrl);
-
-        log.debug("GET SA Resource from {}", url);
-        log.info("About to get self assessment resource from HMRC at {}", url, value(EVENT, HMRC_SA_REQUEST_SENT));
-        Long requestStartTimeStamp = Instant.now().toEpochMilli();
-
-        Resource<String> resource = hmrcCallWrapper.exchange(URI.create(url), GET, createEntityWithHeadersWithoutBody(accessToken), linksResourceTypeRef).getBody();
-        log.info("Self assessment resource response received",
-                value(EVENT, HMRC_SA_RESPONSE_RECEIVED),
-                value(REQUEST_DURATION_TIMESTAMP, calculateRequestDuration(requestStartTimeStamp)));
-        log.debug("SA Response has been received");
-
-        return resource;
-    }
-
     Resource<String> getSelfAssessmentResource(String accessToken, String fromTaxYear, String toTaxYear, Link link) {
 
         if (link == null) {
@@ -287,6 +264,8 @@ public class HmrcHateoasClient {
         log.info("Self assessment resource response received",
                 value(EVENT, HMRC_SA_RESPONSE_RECEIVED),
                 value(REQUEST_DURATION_TIMESTAMP, calculateRequestDuration(requestStartTimeStamp)));
+        log.debug("SA Response has been received");
+
         return resource;
     }
 

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClient.java
@@ -269,6 +269,27 @@ public class HmrcHateoasClient {
         return resource;
     }
 
+    Resource<String> getSelfAssessmentResource(String accessToken, String fromTaxYear, String toTaxYear, Link link) {
+
+        if (link == null) {
+            log.debug("No SA Resource");
+            return new Resource<>("", emptyList());
+        }
+
+        String baseUrl = asAbsolute(link.getHref());
+        String url = buildLinkWithTaxYearRangeQueryParams(fromTaxYear, toTaxYear, baseUrl);
+
+        log.debug("GET SA Resource from {}", url);
+        log.info("About to get self assessment resource from HMRC at {}", url, value(EVENT, HMRC_SA_REQUEST_SENT));
+        Long requestStartTimeStamp = Instant.now().toEpochMilli();
+
+        Resource<String> resource = hmrcCallWrapper.exchange(URI.create(url), GET, createEntityWithHeadersWithoutBody(accessToken), linksResourceTypeRef).getBody();
+        log.info("Self assessment resource response received",
+                value(EVENT, HMRC_SA_RESPONSE_RECEIVED),
+                value(REQUEST_DURATION_TIMESTAMP, calculateRequestDuration(requestStartTimeStamp)));
+        return resource;
+    }
+
     private String asAbsolute(String uri) {
 
         if (uri.startsWith("http")) {

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctions.java
@@ -30,18 +30,6 @@ final class HmrcHateoasClientFunctions {
         return uri;
     }
 
-    static String buildLinkWithTaxYearRangeQueryParams(LocalDate fromDate, LocalDate toDate, String href) {
-        String uri;
-        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(stripPlaceholderQueryParams(href));
-        UriComponentsBuilder withFromDate = uriComponentsBuilder.queryParam(QUERY_PARAM_FROM_TAX_YEAR, getTaxYear(fromDate));
-        if (toDate != null) {
-            uri = withFromDate.queryParam(QUERY_PARAM_TO_TAX_YEAR, getTaxYear(toDate)).build().toUriString();
-        } else {
-            uri = withFromDate.build().toUriString();
-        }
-        return uri;
-    }
-
     static String buildLinkWithTaxYearRangeQueryParams(String fromTaxYear, String toTaxYear, String href) {
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(stripPlaceholderQueryParams(href));
         uriComponentsBuilder.queryParam(QUERY_PARAM_FROM_TAX_YEAR, fromTaxYear);
@@ -53,22 +41,7 @@ final class HmrcHateoasClientFunctions {
                 .toUriString();
     }
 
-    static String getTaxYear(LocalDate date) {
-        String taxYear;
-        if (MonthDay.from(date).isAfter(END_OF_TAX_YEAR)) {
-            taxYear = date.getYear() + "-" + (removeFirstTwoDigits(date.getYear() + 1));
-        } else {
-            taxYear = (date.getYear() - 1) + "-" + removeFirstTwoDigits(date.getYear());
-        }
-        return taxYear;
-    }
-
     private static String stripPlaceholderQueryParams(String href) {
         return href.replaceFirst("\\{&.*\\}", "");
     }
-
-    private static int removeFirstTwoDigits(int fourDigitYear) {
-        return fourDigitYear % 100;
-    }
-
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctions.java
@@ -14,7 +14,7 @@ final class HmrcHateoasClientFunctions {
     private static final String QUERY_PARAM_TO_TAX_YEAR = "toTaxYear";
     private static final String QUERY_PARAM_FROM_TAX_YEAR = "fromTaxYear";
 
-    private HmrcHateoasClientFunctions(){
+    private HmrcHateoasClientFunctions() {
         throw new UnsupportedOperationException("Companion class for HmrcHateoasClient - do not instatiate.");
     }
 

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctions.java
@@ -42,6 +42,17 @@ final class HmrcHateoasClientFunctions {
         return uri;
     }
 
+    static String buildLinkWithTaxYearRangeQueryParams(String fromTaxYear, String toTaxYear, String href) {
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(stripPlaceholderQueryParams(href));
+        uriComponentsBuilder.queryParam(QUERY_PARAM_FROM_TAX_YEAR, fromTaxYear);
+        if (toTaxYear != null) {
+            uriComponentsBuilder.queryParam(QUERY_PARAM_TO_TAX_YEAR, toTaxYear);
+        }
+        return uriComponentsBuilder
+                .build()
+                .toUriString();
+    }
+
     static String getTaxYear(LocalDate date) {
         String taxYear;
         if (MonthDay.from(date).isAfter(END_OF_TAX_YEAR)) {

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
@@ -1,0 +1,27 @@
+package uk.gov.digital.ho.pttg.application;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
+
+public class HmrcClientFunctionsTest {
+
+    private static final LocalDate DATE_5_APRIL_2015 = LocalDate.of(2015, 4, 5);
+    private static final LocalDate DATE_1_MAY_2013 = LocalDate.of(2013, 5, 1);
+    private static final LocalDate DATE_6_APRIL_2011 = LocalDate.of(2011, 4, 6);
+
+    @Test
+    public void shouldReturnTaxYearFromDate() {
+        String taxYear1 = getTaxYear(DATE_5_APRIL_2015);
+        String taxYear2 = getTaxYear(DATE_1_MAY_2013);
+        String taxYear3 = getTaxYear(DATE_6_APRIL_2011);
+
+        assertThat(taxYear1).isEqualTo("2014-15");
+        assertThat(taxYear2).isEqualTo("2013-14");
+        assertThat(taxYear3).isEqualTo("2011-12");
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
@@ -1,37 +1,62 @@
 package uk.gov.digital.ho.pttg.application;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.cglib.core.Local;
 import org.springframework.hateoas.Link;
 import uk.gov.digital.ho.pttg.application.domain.Individual;
 
 import java.time.LocalDate;
+import java.time.Month;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HmrcClientTest {
 
+    @Mock private Link anyLink;
+    @Mock private Individual anyIndividual;
     @Mock private HmrcHateoasClient mockHmrcHateoasClient;
+    @Mock private IncomeSummaryContext mockIncomeSummaryContext;
 
+    private HmrcClient hmrcClient;
+
+    @Before
+    public void setUp() {
+        hmrcClient = new HmrcClient(mockHmrcHateoasClient);
+    }
 
     @Test
     @SuppressFBWarnings(value="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
     public void shouldGetSelfEmployment() {
-        HmrcClient hmrcClient = new HmrcClient(mockHmrcHateoasClient);
+        given(mockIncomeSummaryContext.needsSelfAssessmentSelfEmploymentIncome()).willReturn(true);
+        given(mockIncomeSummaryContext.getSelfAssessmentLink(any(String.class))).willReturn(anyLink);
 
-        IncomeSummaryContext mockIncomeSummaryContext = mock(IncomeSummaryContext.class);
-        when(mockIncomeSummaryContext.needsSelfAssessmentSelfEmploymentIncome()).thenReturn(true);
-        when(mockIncomeSummaryContext.getSelfAssessmentLink(any(String.class))).thenReturn(mock(Link.class));
+        hmrcClient.populateIncomeSummary("some access token", anyIndividual, LocalDate.now(), LocalDate.now(), mockIncomeSummaryContext);
 
-        hmrcClient.populateIncomeSummary("some access token", mock(Individual.class), LocalDate.now(), LocalDate.now(), mockIncomeSummaryContext);
+        then(mockIncomeSummaryContext).should().needsSelfAssessmentSelfEmploymentIncome();
+        then(mockHmrcHateoasClient).should().getSelfAssessmentSelfEmploymentIncome(anyString(), any(Link.class));
+    }
 
-        verify(mockIncomeSummaryContext).needsSelfAssessmentSelfEmploymentIncome();
-        verify(mockHmrcHateoasClient).getSelfAssessmentSelfEmploymentIncome(anyString(), any(Link.class));
+    @Test
+    public void populateIncomeSummary_givenDates_requestSelfAssessmentByTaxYear() {
+        given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
+        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = LocalDate.of(2018, Month.JANUARY, 1);
+        LocalDate toDate = LocalDate.of(2019, Month.JANUARY, 1);
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getSelfAssessmentResource(anyString(), eq("2017-18"), eq("2018-19"), any(Link.class));
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctionsTest.java
@@ -1,15 +1,10 @@
 package uk.gov.digital.ho.pttg.application;
 
-import org.junit.Before;
 import org.junit.Test;
-import uk.gov.digital.ho.pttg.api.RequestHeaderData;
-import uk.gov.digital.ho.pttg.application.namematching.NameMatchingCandidatesService;
-import uk.gov.digital.ho.pttg.application.util.namenormalizer.NameNormalizer;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static uk.gov.digital.ho.pttg.application.HmrcHateoasClientFunctions.*;
 
 public class HmrcHateoasClientFunctionsTest {
@@ -33,10 +28,24 @@ public class HmrcHateoasClientFunctionsTest {
     }
 
     @Test
-    public void shouldRetainAnyReturnedQueryParamsFromAbsoluteUrl_forTaxYearParams() {
+    public void shouldRetainAnyReturnedQueryParamsFromAbsoluteUrl_forTaxYearParamsFromDates() {
         String link = buildLinkWithTaxYearRangeQueryParams(FROM_DATE, TO_DATE, ABSOLUTE_URI_WITH_QUERY_PARAMS_AND_PLACEHOLDER_PARAMS_TAX_YEAR);
         assertThat(link)
                 .isEqualTo(HMRC_BASE_URL + "/individuals?existingParam=123&fromTaxYear=2016-17&toTaxYear=2016-17");
+    }
+
+    @Test
+    public void shouldRetainAnyReturnedQueryParamsFromAbsoluteUrl_forTaxYearParams() {
+        String link = buildLinkWithTaxYearRangeQueryParams("2016-17", "2016-18", ABSOLUTE_URI_WITH_QUERY_PARAMS_AND_PLACEHOLDER_PARAMS_TAX_YEAR);
+        assertThat(link)
+                .isEqualTo(HMRC_BASE_URL + "/individuals?existingParam=123&fromTaxYear=2016-17&toTaxYear=2016-18");
+    }
+
+    @Test
+    public void shouldExcludeToTaxYearIfNotProvided() {
+        String link = buildLinkWithTaxYearRangeQueryParams("2013-14", null, ABSOLUTE_URL_WITHOUT_URL_QUERY_PARAMS);
+        assertThat(link)
+                .isEqualTo(HMRC_BASE_URL + "/individuals?fromTaxYear=2013-14");
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientFunctionsTest.java
@@ -5,7 +5,8 @@ import org.junit.Test;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.digital.ho.pttg.application.HmrcHateoasClientFunctions.*;
+import static uk.gov.digital.ho.pttg.application.HmrcHateoasClientFunctions.buildLinkWithDateRangeQueryParams;
+import static uk.gov.digital.ho.pttg.application.HmrcHateoasClientFunctions.buildLinkWithTaxYearRangeQueryParams;
 
 public class HmrcHateoasClientFunctionsTest {
 
@@ -25,13 +26,6 @@ public class HmrcHateoasClientFunctionsTest {
         String link = buildLinkWithDateRangeQueryParams(FROM_DATE, TO_DATE, ABSOLUTE_URI_WITH_QUERY_PARAMS);
         assertThat(link)
                 .isEqualTo(HMRC_BASE_URL + "/individuals?existingParam=123&fromDate=2016-06-21&toDate=2016-08-01");
-    }
-
-    @Test
-    public void shouldRetainAnyReturnedQueryParamsFromAbsoluteUrl_forTaxYearParamsFromDates() {
-        String link = buildLinkWithTaxYearRangeQueryParams(FROM_DATE, TO_DATE, ABSOLUTE_URI_WITH_QUERY_PARAMS_AND_PLACEHOLDER_PARAMS_TAX_YEAR);
-        assertThat(link)
-                .isEqualTo(HMRC_BASE_URL + "/individuals?existingParam=123&fromTaxYear=2016-17&toTaxYear=2016-17");
     }
 
     @Test
@@ -66,16 +60,4 @@ public class HmrcHateoasClientFunctionsTest {
         String link = buildLinkWithDateRangeQueryParams(FROM_DATE, null, ABSOLUTE_URL_WITHOUT_URL_QUERY_PARAMS);
         assertThat(link).isEqualTo(HMRC_BASE_URL + "/individuals?fromDate=2016-06-21");
     }
-
-    @Test
-    public void shouldReturnTaxYearFromDate() {
-        String taxYear1 = getTaxYear(DATE_5_APRIL_2015);
-        String taxYear2 = getTaxYear(DATE_1_MAY_2013);
-        String taxYear3 = getTaxYear(DATE_6_APRIL_2011);
-
-        assertThat(taxYear1).isEqualTo("2014-15");
-        assertThat(taxYear2).isEqualTo("2013-14");
-        assertThat(taxYear3).isEqualTo("2011-12");
-    }
-
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
@@ -393,39 +393,6 @@ public class HmrcHateoasClientTest {
     public void shouldLogBeforeGetSelfAssessmentResourceRequestSent() {
         given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(mockResponse);
 
-        client.getSelfAssessmentResource("token", LocalDate.of(2000, 1, 1), LocalDate.of(2000, 2, 2), new Link("http://something.com/anyurl"));
-
-        then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
-
-                    return loggingEvent.getFormattedMessage().equals("About to get self assessment resource from HMRC at http://something.com/anyurl?fromTaxYear=1999-0&toTaxYear=1999-0") &&
-                            (loggingEvent.getArgumentArray()[1]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_REQUEST_SENT));
-                }));
-    }
-
-    @Test
-    public void shouldLogAfterSelAssessmentResourceResponseReceived() {
-        given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(mockResponse);
-
-        client.getSelfAssessmentResource("token", LocalDate.of(2000, 1, 1), LocalDate.of(2000, 2, 2), new Link("http://something.com/anyurl"));
-
-        then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
-
-                    return loggingEvent.getFormattedMessage().equals("Self assessment resource response received") &&
-                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_RESPONSE_RECEIVED)) &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
-                }));
-    }
-
-    @Test
-    public void shouldLogBeforeGetSelfAssessmentResourceRequestSent_taxYear() {
-        given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(mockResponse);
-
         client.getSelfAssessmentResource("token", "2010-11", "2011-12", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
@@ -439,7 +406,7 @@ public class HmrcHateoasClientTest {
     }
 
     @Test
-    public void shouldLogAfterSelAssessmentResourceResponseReceived_taxYear() {
+    public void shouldLogAfterSelAssessmentResourceResponseReceived() {
         given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(mockResponse);
 
         client.getSelfAssessmentResource("token", "2010-11", "2011-12", new Link("http://something.com/anyurl"));

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
@@ -424,49 +424,41 @@ public class HmrcHateoasClientTest {
 
     @Test
     public void shouldLogBeforeGetSelfAssessmentResourceRequestSent_taxYear() {
-        // given
-        when(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(mockResponse);
+        given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(mockResponse);
 
-        HmrcHateoasClient client = new HmrcHateoasClient(mockRequestHeaderData, mockNameNormalizer, mockHmrcCallWrapper, mockNameMatchingCandidatesService, "http://foo.com/bar");
-
-        // when
         client.getSelfAssessmentResource("token", "2010-11", "2011-12", new Link("http://something.com/anyurl"));
 
-        // then
-        verify(mockAppender).doAppend(argThat(argument -> {
-            LoggingEvent loggingEvent = (LoggingEvent) argument;
+        then(mockAppender)
+                .should()
+                .doAppend(argThat(argument -> {
+                    LoggingEvent loggingEvent = (LoggingEvent) argument;
 
-            return loggingEvent.getFormattedMessage().equals("About to get self assessment resource from HMRC at http://something.com/anyurl?fromTaxYear=2010-11&toTaxYear=2011-12") &&
-                    (loggingEvent.getArgumentArray()[1]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_REQUEST_SENT));
-        }));
+                    return loggingEvent.getFormattedMessage().equals("About to get self assessment resource from HMRC at http://something.com/anyurl?fromTaxYear=2010-11&toTaxYear=2011-12") &&
+                            (loggingEvent.getArgumentArray()[1]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_REQUEST_SENT));
+                }));
     }
 
     @Test
     public void shouldLogAfterSelAssessmentResourceResponseReceived_taxYear() {
-        // given
-        when(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(mockResponse);
+        given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(mockResponse);
 
-        HmrcHateoasClient client = new HmrcHateoasClient(mockRequestHeaderData, mockNameNormalizer, mockHmrcCallWrapper, mockNameMatchingCandidatesService, "http://foo.com/bar");
-
-        // when
         client.getSelfAssessmentResource("token", "2010-11", "2011-12", new Link("http://something.com/anyurl"));
 
-        // then
-        verify(mockAppender).doAppend(argThat(argument -> {
-            LoggingEvent loggingEvent = (LoggingEvent) argument;
+        then(mockAppender)
+                .should()
+                .doAppend(argThat(argument -> {
+                    LoggingEvent loggingEvent = (LoggingEvent) argument;
 
-            return loggingEvent.getFormattedMessage().equals("Self assessment resource response received") &&
-                    (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_RESPONSE_RECEIVED)) &&
-                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
-        }));
+                    return loggingEvent.getFormattedMessage().equals("Self assessment resource response received") &&
+                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_RESPONSE_RECEIVED)) &&
+                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
+                }));
     }
 
     @Test
     public void getSelfAssessmentResource_responseFromCallWrapper_returnedToCaller() {
         ResponseEntity someResponse = new ResponseEntity<>(new Resource<>("some response"), OK);
-        when(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(someResponse);
-
-        HmrcHateoasClient client = new HmrcHateoasClient(mockRequestHeaderData, mockNameNormalizer, mockHmrcCallWrapper, mockNameMatchingCandidatesService, "http://foo.com/bar");
+        given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(someResponse);
 
         Resource<String> returnedResponse = client.getSelfAssessmentResource("token", "2010-11", "2011-12", new Link("http://something.com/anyurl"));
 
@@ -475,10 +467,6 @@ public class HmrcHateoasClientTest {
 
     @Test
     public void getSelfAssessmentResource_nullLink_returnEmptyResource() {
-        when(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(mockResponse);
-
-        HmrcHateoasClient client = new HmrcHateoasClient(mockRequestHeaderData, mockNameNormalizer, mockHmrcCallWrapper, mockNameMatchingCandidatesService, "http://foo.com/bar");
-
         Resource<String> returnedResponse = client.getSelfAssessmentResource("token", "2010-11", "2011-12", null);
 
         assertThat(returnedResponse.getContent()).isEqualTo("");


### PR DESCRIPTION
I've pulled the conversion from LocalDates to tax years (as Strings) out of the the HmrcHateoasClient's buildLinkWithTaxYearRangeQueryParams and moved it into the HmrcClient.

To this end, buildLinkWithTaxYearRangeQueryParams and all the methods that lead up to it from HmrcClient.storeSelfAssessmentResource have been changed to expect tax years as parameters. Also some functions in HmrcHateoasClientFunctions have been moved HmrcClientFunctions. 

I've made this change because I plan to make the calculation of tax years more involved (so that it will not ask for data more than 6 tax years ago). The HmrcClient feels like a more appropriate place to do this work than the HmrcHateoasClient.