### PR TITLE
EE-17546 Fixed the getTaxYear function

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
@@ -21,7 +21,8 @@ final class HmrcClientFunctions {
         return taxYear;
     }
 
-    private static int removeFirstTwoDigits(int fourDigitYear) {
-        return fourDigitYear % 100;
+    private static String removeFirstTwoDigits(int fourDigitYear) {
+        int oneOrTwoDigitYear = fourDigitYear % 100;
+        return String.format("%02d", oneOrTwoDigitYear);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
@@ -24,4 +24,21 @@ public class HmrcClientFunctionsTest {
         assertThat(taxYear3).isEqualTo("2011-12");
     }
 
+    @Test
+    public void getTaxYear_dateBefore2010_returnTaxYear() {
+        assertThat(getTaxYear(LocalDate.of(2001, 1, 1)))
+                .isEqualTo("2000-01");
+    }
+
+    @Test
+    public void getTaxYear_dateAfter2100_returnTaxYear() {
+        assertThat(getTaxYear(LocalDate.of(2100, 1, 1)))
+                .isEqualTo("2099-00");
+    }
+
+    @Test
+    public void getTaxYear_taxYear1999_2000_returnTaxYear() {
+        assertThat(getTaxYear(LocalDate.of(2000, 1, 1)))
+                .isEqualTo("1999-00");
+    }
 }


### PR DESCRIPTION
 Ensure that it will return a correctly formatted tax year when the 2 digit date is less than 10. Not an urgent issue as I don't believe it will affect us until the year 2100. But since I was already working in the area, I though it worth a quick fix.