### PR TITLE
Ee 17546 Self Assessment rolling window

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -9,7 +9,6 @@ import uk.gov.digital.ho.pttg.application.domain.Individual;
 import java.time.LocalDate;
 
 import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
-import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYearForDateOrEarliestAllowed;
 
 @Service
 @Slf4j
@@ -112,7 +111,10 @@ public class HmrcClient {
 
     private void storeSelfAssessmentResource(String accessToken, LocalDate fromDate, LocalDate toDate, IncomeSummaryContext context) {
         String toTaxYear = getTaxYear(toDate);
-        String fromTaxYear = getTaxYearForDateOrEarliestAllowed(fromDate, earliestAllowedTaxYear());
+        String fromTaxYear = getTaxYear(fromDate);
+        if (isTooLongAgo(fromTaxYear)) {
+            fromTaxYear = earliestAllowedTaxYear();
+        }
 
         storeSelfAssessmentResource(accessToken, fromTaxYear, toTaxYear, context);
     }
@@ -127,4 +129,7 @@ public class HmrcClient {
         return getTaxYear(LocalDate.now().minusYears(maximumTaxYearHistory));
     }
 
+    private boolean isTooLongAgo(String taxYear) {
+        return Integer.parseInt(taxYear.substring(0, 4)) < Integer.parseInt(earliestAllowedTaxYear().substring(0, 4));
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -9,6 +9,7 @@ import uk.gov.digital.ho.pttg.application.domain.Individual;
 import java.time.Clock;
 import java.time.LocalDate;
 
+import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYearForDateOrEarliestAllowed;
 import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
 
 @Service
@@ -115,10 +116,7 @@ public class HmrcClient {
 
     private void storeSelfAssessmentResource(String accessToken, LocalDate fromDate, LocalDate toDate, IncomeSummaryContext context) {
         String toTaxYear = getTaxYear(toDate);
-        String fromTaxYear = getTaxYear(fromDate);
-        if (isTooLongAgo(fromTaxYear)) {
-            fromTaxYear = earliestAllowedTaxYear();
-        }
+        String fromTaxYear = getTaxYearForDateOrEarliestAllowed(fromDate, earliestAllowedTaxYear());
 
         storeSelfAssessmentResource(accessToken, fromTaxYear, toTaxYear, context);
     }
@@ -133,7 +131,4 @@ public class HmrcClient {
         return getTaxYear(LocalDate.now(clock).minusYears(maximumTaxYearHistory));
     }
 
-    private boolean isTooLongAgo(String taxYear) {
-        return Integer.parseInt(taxYear.substring(0, 4)) < Integer.parseInt(earliestAllowedTaxYear().substring(0, 4));
-    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -6,18 +6,16 @@ import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.pttg.application.domain.IncomeSummary;
 import uk.gov.digital.ho.pttg.application.domain.Individual;
 
-import java.time.Clock;
 import java.time.LocalDate;
 
-import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYearForDateOrEarliestAllowed;
 import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
+import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYearForDateOrEarliestAllowed;
 
 @Service
 @Slf4j
 public class HmrcClient {
 
     private final HmrcHateoasClient hateoasClient;
-    private final Clock clock;
     private final int maximumTaxYearHistory;
 
     /*
@@ -32,10 +30,8 @@ public class HmrcClient {
     private static final String SA_SELF_EMPLOYMENTS = "selfEmployments";
 
     public HmrcClient(HmrcHateoasClient hateoasClient,
-                      Clock clock,
                       @Value("#{${hmrc.self-assessment.tax-years.history.maximum:1000}}") int maximumSelfAssessmentTaxYearHistory) {
         this.hateoasClient = hateoasClient;
-        this.clock = clock;
         this.maximumTaxYearHistory = maximumSelfAssessmentTaxYearHistory;
     }
 
@@ -128,7 +124,7 @@ public class HmrcClient {
     }
 
     private String earliestAllowedTaxYear() {
-        return getTaxYear(LocalDate.now(clock).minusYears(maximumTaxYearHistory));
+        return getTaxYear(LocalDate.now().minusYears(maximumTaxYearHistory));
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.pttg.application;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.pttg.application.domain.IncomeSummary;
 import uk.gov.digital.ho.pttg.application.domain.Individual;
@@ -16,6 +17,7 @@ public class HmrcClient {
 
     private final HmrcHateoasClient hateoasClient;
     private final Clock clock;
+    private final int maximumTaxYearHistory;
 
     /*
         Hypermedia paths and links
@@ -28,9 +30,12 @@ public class HmrcClient {
     private static final String PAYE_EMPLOYMENT = "paye";
     private static final String SA_SELF_EMPLOYMENTS = "selfEmployments";
 
-    public HmrcClient(HmrcHateoasClient hateoasClient, Clock clock) {
+    public HmrcClient(HmrcHateoasClient hateoasClient,
+                      Clock clock,
+                      @Value("#{${hmrc.self-assessment.tax-years.history.maximum:1000}}") int maximumSelfAssessmentTaxYearHistory) {
         this.hateoasClient = hateoasClient;
         this.clock = clock;
+        this.maximumTaxYearHistory = maximumSelfAssessmentTaxYearHistory;
     }
 
     public IncomeSummary populateIncomeSummary(String accessToken, Individual suppliedIndividual, LocalDate fromDate, LocalDate toDate, IncomeSummaryContext context) {
@@ -125,7 +130,7 @@ public class HmrcClient {
     }
 
     private String earliestAllowedTaxYear() {
-        return getTaxYear(LocalDate.now(clock).minusYears(6));
+        return getTaxYear(LocalDate.now(clock).minusYears(maximumTaxYearHistory));
     }
 
     private boolean isTooLongAgo(String taxYear) {

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -30,7 +30,7 @@ public class HmrcClient {
     private static final String SA_SELF_EMPLOYMENTS = "selfEmployments";
 
     public HmrcClient(HmrcHateoasClient hateoasClient,
-                      @Value("#{${hmrc.self-assessment.tax-years.history.maximum:1000}}") int maximumSelfAssessmentTaxYearHistory) {
+                      @Value("${hmrc.self-assessment.tax-years.history.maximum:1000}") int maximumSelfAssessmentTaxYearHistory) {
         this.hateoasClient = hateoasClient;
         this.maximumTaxYearHistory = maximumSelfAssessmentTaxYearHistory;
     }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
@@ -21,8 +21,20 @@ final class HmrcClientFunctions {
         return taxYear;
     }
 
+    static String getTaxYearForDateOrEarliestAllowed(LocalDate date, String earliestAllowedTaxYear) {
+        String fromTaxYear = getTaxYear(date);
+        if (isTooLongAgo(fromTaxYear, earliestAllowedTaxYear)) {
+            return earliestAllowedTaxYear;
+        }
+        return fromTaxYear;
+    }
+
     private static String removeFirstTwoDigits(int fourDigitYear) {
         int oneOrTwoDigitYear = fourDigitYear % 100;
         return String.format("%02d", oneOrTwoDigitYear);
+    }
+
+    private static boolean isTooLongAgo(String taxYear, String earliestAllowedTaxYear) {
+        return Integer.parseInt(taxYear.substring(0, 4)) < Integer.parseInt(earliestAllowedTaxYear.substring(0, 4));
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctions.java
@@ -21,20 +21,8 @@ final class HmrcClientFunctions {
         return taxYear;
     }
 
-    static String getTaxYearForDateOrEarliestAllowed(LocalDate date, String earliestAllowedTaxYear) {
-        String fromTaxYear = getTaxYear(date);
-        if (isTooLongAgo(fromTaxYear, earliestAllowedTaxYear)) {
-            return earliestAllowedTaxYear;
-        }
-        return fromTaxYear;
-    }
-
     private static String removeFirstTwoDigits(int fourDigitYear) {
         int oneOrTwoDigitYear = fourDigitYear % 100;
         return String.format("%02d", oneOrTwoDigitYear);
-    }
-
-    private static boolean isTooLongAgo(String taxYear, String earliestAllowedTaxYear) {
-        return Integer.parseInt(taxYear.substring(0, 4)) < Integer.parseInt(earliestAllowedTaxYear.substring(0, 4));
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
@@ -3,11 +3,9 @@ package uk.gov.digital.ho.pttg.application;
 import org.junit.Test;
 
 import java.time.LocalDate;
-import java.time.Month;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
-import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYearForDateOrEarliestAllowed;
 
 public class HmrcClientFunctionsTest {
 
@@ -42,24 +40,5 @@ public class HmrcClientFunctionsTest {
     public void getTaxYear_taxYear1999_2000_returnTaxYear() {
         assertThat(getTaxYear(LocalDate.of(2000, 1, 1)))
                 .isEqualTo("1999-00");
-    }
-
-    @Test
-    public void getTaxYearForDateOrEarliestAllowed_dateAfterEarliestAllowed_returnTaxYearForDate() {
-        LocalDate afterEarliestAllowed = LocalDate.of(2013, Month.APRIL,5); // Tax year 2012-13
-        assertThat(getTaxYearForDateOrEarliestAllowed(afterEarliestAllowed, "2011-12"))
-                .isEqualTo("2012-13");
-    }
-    @Test
-    public void getTaxYearForDateOrEarliestAllowed_dateIsEarliestAllowed_returnTaxYearForDate() {
-        LocalDate sameAsEarliestAllowed = LocalDate.of(2011, Month.APRIL,6); // Tax year 2011-12
-        assertThat(getTaxYearForDateOrEarliestAllowed(sameAsEarliestAllowed, "2011-12"))
-                .isEqualTo("2011-12");
-    }
-    @Test
-    public void getTaxYearForDateOrEarliestAllowed_dateBeforeEarliestAllowed_returnEarliestAllowed() {
-        LocalDate beforeEarliestAllowed = LocalDate.of(2011, Month.APRIL,5); // Tax year 2010-11
-        assertThat(getTaxYearForDateOrEarliestAllowed(beforeEarliestAllowed, "2011-12"))
-                .isEqualTo("2011-12");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
@@ -3,9 +3,12 @@ package uk.gov.digital.ho.pttg.application;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
+import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYearForDateOrEarliestAllowed;
 
 public class HmrcClientFunctionsTest {
 
@@ -40,5 +43,24 @@ public class HmrcClientFunctionsTest {
     public void getTaxYear_taxYear1999_2000_returnTaxYear() {
         assertThat(getTaxYear(LocalDate.of(2000, 1, 1)))
                 .isEqualTo("1999-00");
+    }
+
+    @Test
+    public void getTaxYearForDateOrEarliestAllowed_dateAfterEarliestAllowed_returnTaxYearForDate() {
+        LocalDate afterEarliestAllowed = LocalDate.of(2013, Month.APRIL,5); // Tax year 2012-13
+        assertThat(getTaxYearForDateOrEarliestAllowed(afterEarliestAllowed, "2011-12"))
+                .isEqualTo("2012-13");
+    }
+    @Test
+    public void getTaxYearForDateOrEarliestAllowed_dateIsEarliestAllowed_returnTaxYearForDate() {
+        LocalDate sameAsEarliestAllowed = LocalDate.of(2011, Month.APRIL,6); // Tax year 2011-12
+        assertThat(getTaxYearForDateOrEarliestAllowed(sameAsEarliestAllowed, "2011-12"))
+                .isEqualTo("2011-12");
+    }
+    @Test
+    public void getTaxYearForDateOrEarliestAllowed_dateBeforeEarliestAllowed_returnEarliestAllowed() {
+        LocalDate beforeEarliestAllowed = LocalDate.of(2011, Month.APRIL,5); // Tax year 2010-11
+        assertThat(getTaxYearForDateOrEarliestAllowed(beforeEarliestAllowed, "2011-12"))
+                .isEqualTo("2011-12");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientFunctionsTest.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 import java.time.Month;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
 import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYearForDateOrEarliestAllowed;
 

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
@@ -9,18 +9,18 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.hateoas.Link;
 import uk.gov.digital.ho.pttg.application.domain.Individual;
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.Month;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.eq;
+import static uk.gov.digital.ho.pttg.application.HmrcClientFunctions.getTaxYear;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HmrcClientTest {
-
-    private static final LocalDate TODAY = LocalDate.of(2018, Month.JANUARY, 1);
 
     @Mock private Link anyLink;
     @Mock private Individual anyIndividual;
@@ -31,7 +31,7 @@ public class HmrcClientTest {
 
     @Before
     public void setUp() {
-        hmrcClient = clientWithClockFixedAtDate(TODAY.atStartOfDay());
+        hmrcClient = new HmrcClient(mockHmrcHateoasClient, 6);
     }
 
     @Test
@@ -51,89 +51,49 @@ public class HmrcClientTest {
         given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
         given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
 
-        LocalDate fromDate = LocalDate.of(2018, Month.JANUARY, 1);
-        LocalDate toDate = LocalDate.of(2019, Month.JANUARY, 1);
+        LocalDate fromDate = LocalDate.now().minusYears(2);
+        LocalDate toDate = LocalDate.now().minusYears(3);
         hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
 
+        String expectedFromTaxYear = getTaxYear(fromDate);
+        String expectedToTaxYear = getTaxYear(toDate);
         then(mockHmrcHateoasClient)
                 .should()
-                .getSelfAssessmentResource(anyString(), eq("2017-18"), eq("2018-19"), any(Link.class));
+                .getSelfAssessmentResource(anyString(), eq(expectedFromTaxYear), eq(expectedToTaxYear), any(Link.class));
     }
 
     @Test
-    public void populateIncomeSummary_startOfTaxYear_fromDate6TaxYearsAgo_requestAllTaxYears() {
+    public void populateIncomeSummary_fromDate6TaxYearsAgo_requestAllTaxYears() {
         given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
         given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
 
-        // Tax year 2019-20
-        LocalDateTime startOfTaxYear = LocalDate.of(2019, Month.APRIL, 6).atStartOfDay();
-        HmrcClient hmrcClient = clientWithClockFixedAtDate(startOfTaxYear);
-
-        LocalDate toDate = LocalDate.of(2019, Month.APRIL, 6); // Tax year 2019-20
-        LocalDate fromDate = LocalDate.of(2013, Month.APRIL, 6); // Tax year 2013-14
+        LocalDate toDate = LocalDate.now();
+        LocalDate fromDate = toDate.minusYears(6);
 
         hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
 
+        String expectedFromTaxYear = getTaxYear(fromDate);
+        String expectedToTaxYear = getTaxYear(toDate);
         then(mockHmrcHateoasClient)
                 .should()
-                .getSelfAssessmentResource(anyString(), eq("2013-14"), eq("2019-20"), any(Link.class));
+                .getSelfAssessmentResource(anyString(), eq(expectedFromTaxYear), eq(expectedToTaxYear), any(Link.class));
     }
 
     @Test
-    public void populateIncomeSummary_startOfTaxYear_fromDate7TaxYearsAgo_toDateSixTaxYearsAgo() {
+    public void populateIncomeSummary_fromDate7TaxYearsAgo_toDateSixTaxYearsAgo() {
         given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
         given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
 
-        // Tax year 2019-20
-        LocalDateTime startOfTaxYear = LocalDate.of(2019, Month.APRIL, 6).atStartOfDay();
-        HmrcClient hmrcClient = clientWithClockFixedAtDate(startOfTaxYear);
-
-        LocalDate toDate = LocalDate.of(2019, Month.APRIL, 6); // Tax year 2019-20
-        LocalDate fromDate = LocalDate.of(2012, Month.APRIL, 6); // Tax year 2012-13
+        LocalDate toDate = LocalDate.now();
+        LocalDate fromDate = toDate.minusYears(7);
 
         hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
 
+        String expectedFromTaxYear = getTaxYear(fromDate.plusYears(1));
+        String expectedToTaxYear = getTaxYear(toDate);
         then(mockHmrcHateoasClient)
                 .should()
-                .getSelfAssessmentResource(anyString(), eq("2013-14"), eq("2019-20"), any(Link.class));
-    }
-
-    @Test
-    public void populateIncomeSummary_endOfTaxYear_fromDate6TaxYearsAgo_requestAllTaxYears() {
-        given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
-        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
-
-        // Tax year 2018-19
-        LocalDateTime endOfTaxYear = LocalDate.of(2019, Month.APRIL, 5).atTime(23,59,59,999_999_999);
-        HmrcClient hmrcClient = clientWithClockFixedAtDate(endOfTaxYear);
-
-        LocalDate toDate = LocalDate.of(2019, Month.APRIL, 5); // Tax year 2018-19
-        LocalDate fromDate = LocalDate.of(2012, Month.APRIL, 6); // Tax year 2012-13
-
-        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
-
-        then(mockHmrcHateoasClient)
-                .should()
-                .getSelfAssessmentResource(anyString(), eq("2012-13"), eq("2018-19"), any(Link.class));
-    }
-
-    @Test
-    public void populateIncomeSummary_endOfTaxYear_fromDate7TaxYearsAgo_toDateSixTaxYearsAgo() {
-        given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
-        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
-
-        // Tax year 2018-19
-        LocalDateTime endOfTaxYear = LocalDate.of(2019, Month.APRIL, 5).atTime(23,59,59,999_999_999);
-        HmrcClient hmrcClient = clientWithClockFixedAtDate(endOfTaxYear);
-
-        LocalDate toDate = LocalDate.of(2019, Month.APRIL, 5); // Tax year 2018-19
-        LocalDate fromDate = LocalDate.of(2012, Month.APRIL, 5); // Tax year 2011-12
-
-        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
-
-        then(mockHmrcHateoasClient)
-                .should()
-                .getSelfAssessmentResource(anyString(), eq("2012-13"), eq("2018-19"), any(Link.class));
+                .getSelfAssessmentResource(anyString(), eq(expectedFromTaxYear), eq(expectedToTaxYear), any(Link.class));
     }
 
     @Test
@@ -141,14 +101,16 @@ public class HmrcClientTest {
         given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
         given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
 
-        LocalDate toDate = LocalDate.of(2013, Month.JANUARY, 1); // Tax year 2012-03
-        LocalDate fromDate = LocalDate.of(2007, Month.JANUARY, 1); // Tax year 2006-07
+        LocalDate toDate = LocalDate.now().minusYears(5);
+        LocalDate fromDate = toDate.minusYears(6);
 
         hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
 
+        String expectedFromTaxYear = getTaxYear(LocalDate.now().minusYears(6));
+        String expectedToTaxYear = getTaxYear(toDate);
         then(mockHmrcHateoasClient)
                 .should()
-                .getSelfAssessmentResource(anyString(), eq("2011-12"), eq("2012-13"), any(Link.class));
+                .getSelfAssessmentResource(anyString(), eq(expectedFromTaxYear), eq(expectedToTaxYear), any(Link.class));
     }
 
     @Test
@@ -159,21 +121,12 @@ public class HmrcClientTest {
         LocalDate toDate = LocalDate.of(2019, Month.JANUARY, 1); // Tax year 2018-19
         LocalDate fromDate = LocalDate.of(2000, Month.JANUARY, 1); // Tax year 1999-00
 
-        HmrcClient hmrcClient = clientWithClockFixedAndMaxHistory(toDate.atStartOfDay(), 1000);
+        HmrcClient hmrcClient = new HmrcClient(mockHmrcHateoasClient, 1000);
 
         hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
 
         then(mockHmrcHateoasClient)
                 .should()
                 .getSelfAssessmentResource(anyString(), eq("1999-00"), eq("2018-19"), any(Link.class));
-    }
-
-    private HmrcClient clientWithClockFixedAtDate(LocalDateTime dateTime) {
-        return clientWithClockFixedAndMaxHistory(dateTime, 6);
-    }
-
-    private HmrcClient clientWithClockFixedAndMaxHistory(LocalDateTime dateTime, int maxSelfAssesmentTaxYearHistory) {
-        Clock fixedClock = Clock.fixed(dateTime.toInstant(ZoneOffset.UTC), ZoneOffset.UTC);
-        return new HmrcClient(mockHmrcHateoasClient, fixedClock, maxSelfAssesmentTaxYearHistory);
     }
 }


### PR DESCRIPTION
Updated the HmrcClient so that it will override the fromTaxYear if it is too far in the past. The number of years that you can go back is a config item. I have intentionally not provided a value for this and set the default to 1000. 

I believe that by setting the maximum allowed range to 1000 years I have not changed the behaviour of this service - I have added tests to confirm this. However it would be prudent to do some regression testing, which I have raised a ticket for (EE-17546).

I will then raise PRs to add the real-life value of 6 years to config (application.properties; eue-api-helm-project; and kube-pttg-ip-hmrc). These will be the "feature" PRs to be tested manually before merging