### PR TITLE
EE-17546 Added an HMRC PAYE Epoch

### DIFF
--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientDefaultValuesSpringTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientDefaultValuesSpringTest.java
@@ -1,0 +1,39 @@
+package uk.gov.digital.ho.pttg.application;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {HmrcClient.class, HmrcClientDefaultValuesSpringTest.TestConfig.class})
+public class HmrcClientDefaultValuesSpringTest {
+
+    @Autowired
+    public HmrcClient hmrcClient;
+
+    @Test
+    public void autowiring_noPropertiesSet_payeEpochLocalDateMIN() {
+        LocalDate payeDataEpoch = (LocalDate) ReflectionTestUtils.getField(hmrcClient, "payeDataEpoch");
+        assertThat(payeDataEpoch)
+                .isEqualTo(LocalDate.MIN);
+    }
+
+    @EnableConfigurationProperties
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public HmrcHateoasClient hmrcHateoasClient() {
+            return new HmrcHateoasClient(null, null, null, null, null);
+        }
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class HmrcClientTest {
 
+    private static final LocalDate DEFAULT_PAYE_EPOCH = LocalDate.of(2013, Month.MARCH, 31);
+
     @Mock private Link anyLink;
     @Mock private Individual anyIndividual;
     @Mock private HmrcHateoasClient mockHmrcHateoasClient;
@@ -31,7 +33,7 @@ public class HmrcClientTest {
 
     @Before
     public void setUp() {
-        hmrcClient = new HmrcClient(mockHmrcHateoasClient);
+        hmrcClient = new HmrcClient(mockHmrcHateoasClient, DEFAULT_PAYE_EPOCH);
     }
 
     @Test
@@ -58,5 +60,127 @@ public class HmrcClientTest {
         then(mockHmrcHateoasClient)
                 .should()
                 .getSelfAssessmentResource(anyString(), eq("2017-18"), eq("2018-19"), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeIncome_fromDateAfterEpoch_useInRequest() {
+        given(mockIncomeSummaryContext.needsPayeIncome()).willReturn(true);
+        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = DEFAULT_PAYE_EPOCH.plusDays(1);
+        LocalDate toDate = LocalDate.now();
+
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getPayeIncome(eq(fromDate), eq(toDate), anyString(), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeIncome_fromDateOnEpoch_useInRequest() {
+        given(mockIncomeSummaryContext.needsPayeIncome()).willReturn(true);
+        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = DEFAULT_PAYE_EPOCH;
+        LocalDate toDate = LocalDate.now();
+
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getPayeIncome(eq(fromDate), eq(toDate), anyString(), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeIncome_fromDateBeforeEpoch_useEpoch() {
+        given(mockIncomeSummaryContext.needsPayeIncome()).willReturn(true);
+        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = DEFAULT_PAYE_EPOCH.minusDays(1);
+        LocalDate toDate = LocalDate.now();
+
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getPayeIncome(eq(DEFAULT_PAYE_EPOCH), eq(toDate), anyString(), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeIncome_epochLocalDateMin_doNotRestrictFromDate() {
+        given(mockIncomeSummaryContext.needsPayeIncome()).willReturn(true);
+        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = LocalDate.of(1900, Month.JANUARY, 1);
+        LocalDate toDate = LocalDate.now();
+
+        HmrcClient hmrcClient = new HmrcClient(mockHmrcHateoasClient, LocalDate.MIN);
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getPayeIncome(eq(fromDate), eq(toDate), anyString(), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeEmployments_fromDateAfterEpoch_useInRequest() {
+        given(mockIncomeSummaryContext.needsEmployments()).willReturn(true);
+        given(mockIncomeSummaryContext.getEmploymentLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = DEFAULT_PAYE_EPOCH.plusDays(1);
+        LocalDate toDate = LocalDate.now();
+
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getEmployments(eq(fromDate), eq(toDate), anyString(), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeEmployments_fromDateOnEpoch_useInRequest() {
+        given(mockIncomeSummaryContext.needsEmployments()).willReturn(true);
+        given(mockIncomeSummaryContext.getEmploymentLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = DEFAULT_PAYE_EPOCH;
+        LocalDate toDate = LocalDate.now();
+
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getEmployments(eq(fromDate), eq(toDate), anyString(), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeEmployments_fromDateBeforeEpoch_useEpoch() {
+        given(mockIncomeSummaryContext.needsEmployments()).willReturn(true);
+        given(mockIncomeSummaryContext.getEmploymentLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = DEFAULT_PAYE_EPOCH.minusDays(1);
+        LocalDate toDate = LocalDate.now();
+
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getEmployments(eq(DEFAULT_PAYE_EPOCH), eq(toDate), anyString(), any(Link.class));
+    }
+
+    @Test
+    public void populateIncomeSummary_payeEmployments_epochLocalDateMin_doNotRestrictFromDate() {
+        given(mockIncomeSummaryContext.needsEmployments()).willReturn(true);
+        given(mockIncomeSummaryContext.getEmploymentLink(anyString())).willReturn(anyLink);
+
+        LocalDate fromDate = LocalDate.of(1900, Month.JANUARY, 1);
+        LocalDate toDate = LocalDate.now();
+
+        HmrcClient hmrcClient = new HmrcClient(mockHmrcHateoasClient, LocalDate.MIN);
+        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
+
+        then(mockHmrcHateoasClient)
+                .should()
+                .getEmployments(eq(fromDate), eq(toDate), anyString(), any(Link.class));
     }
 }


### PR DESCRIPTION
The fromDate for PAYE requests will never be before this date. Also made the default epoch LocalDate.MIN so that until the value is changed in config, behaviour of the application will not be changed.

This PR would benefit from some regression testing, similar to https://github.com/UKHomeOffice/pttg-ip-hmrc/pull/187 - the JIRA is EE-18301

I've set the epoch to be a date because the HMRC documentation says that a fromDate prior to 31st March 2013 will be rejected. There's an ongoing discussion to with HMRC to check that there isn't a rolling tax year window too, like with SA, but we still should set the epoch date.