### PR TITLE
Ee 17546 add sa config local

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcClient.java
@@ -29,7 +29,7 @@ public class HmrcClient {
     private static final String SA_SELF_EMPLOYMENTS = "selfEmployments";
 
     public HmrcClient(HmrcHateoasClient hateoasClient,
-                      @Value("${hmrc.self-assessment.tax-years.history.maximum:1000}") int maximumSelfAssessmentTaxYearHistory) {
+                      @Value("${hmrc.self-assessment.tax-years.history.maximum}") int maximumSelfAssessmentTaxYearHistory) {
         this.hateoasClient = hateoasClient;
         this.maximumTaxYearHistory = maximumSelfAssessmentTaxYearHistory;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,8 @@ timeouts.hmrc-access-code.connect-ms=1000
 
 hmrc.name.rules.length.max=35
 
+hmrc.self-assessment.tax-years.history.maximum=6
+
 #
 # HMRC endpoints
 #

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientPayeEpochTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientPayeEpochTest.java
@@ -46,7 +46,7 @@ public class HmrcClientPayeEpochTest {
         given(mockIncomeSummaryContext.needsEmployments()).willReturn(true);
         given(mockIncomeSummaryContext.getEmploymentLink(anyString())).willReturn(anyLink);
 
-        hmrcClient = new HmrcClient(mockHmrcHateoasClient,6 , epoch);
+        hmrcClient = new HmrcClient(mockHmrcHateoasClient, 6, epoch);
     }
 
     @Parameterized.Parameters(name = "When requesting a fromDate of {0}, with and epoch of {1} the date of {2} will actually be used")

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientPayeEpochTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientPayeEpochTest.java
@@ -46,7 +46,7 @@ public class HmrcClientPayeEpochTest {
         given(mockIncomeSummaryContext.needsEmployments()).willReturn(true);
         given(mockIncomeSummaryContext.getEmploymentLink(anyString())).willReturn(anyLink);
 
-        hmrcClient = new HmrcClient(mockHmrcHateoasClient, epoch);
+        hmrcClient = new HmrcClient(mockHmrcHateoasClient,6 , epoch);
     }
 
     @Parameterized.Parameters(name = "When requesting a fromDate of {0}, with and epoch of {1} the date of {2} will actually be used")

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcClientTest.java
@@ -112,21 +112,4 @@ public class HmrcClientTest {
                 .should()
                 .getSelfAssessmentResource(anyString(), eq(expectedFromTaxYear), eq(expectedToTaxYear), any(Link.class));
     }
-
-    @Test
-    public void populateIncomeSummary_maximumHistoryIs1000_doNotRestrictTaxYears() {
-        given(mockIncomeSummaryContext.needsSelfAssessmentResource()).willReturn(true);
-        given(mockIncomeSummaryContext.getIncomeLink(anyString())).willReturn(anyLink);
-
-        LocalDate toDate = LocalDate.of(2019, Month.JANUARY, 1); // Tax year 2018-19
-        LocalDate fromDate = LocalDate.of(2000, Month.JANUARY, 1); // Tax year 1999-00
-
-        HmrcClient hmrcClient = new HmrcClient(mockHmrcHateoasClient, 1000);
-
-        hmrcClient.populateIncomeSummary("any access token", anyIndividual, fromDate, toDate, mockIncomeSummaryContext);
-
-        then(mockHmrcHateoasClient)
-                .should()
-                .getSelfAssessmentResource(anyString(), eq("1999-00"), eq("2018-19"), any(Link.class));
-    }
 }


### PR DESCRIPTION
Added Self Assessment history limit into local config and removed the default so that the value must be set in config.

This ticket should not be merged before EE-17546-sa-rolling-window (https://github.com/UKHomeOffice/pttg-ip-hmrc/pull/187) as it builds on that branch. Diffing against that branch should make reviewing easier also.