### PR TITLE
EE 15233 hmrc hateoas client test refactor and improvement

### DIFF
--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
@@ -106,7 +106,7 @@ public class HmrcHateoasClientTest {
                     LoggingEvent loggingEvent = (LoggingEvent) argument;
 
                     return loggingEvent.getFormattedMessage().equals("Match Individual NR123456C via a POST to http://localhost/individuals/matching/") &&
-                            loggingEvent.getArgumentArray()[2].equals(new ObjectAppendingMarker("event_id", HMRC_MATCHING_REQUEST_SENT));
+                            loggingEvent.getArgumentArray()[2].equals(new ObjectAppendingMarker(EVENT, HMRC_MATCHING_REQUEST_SENT));
                 }));
     }
 
@@ -124,7 +124,7 @@ public class HmrcHateoasClientTest {
         assertThat(loggingEvent.getFormattedMessage()).isEqualTo("Successfully matched individual NR123456C");
         assertThat(loggingEvent.getArgumentArray())
                 .contains(new ObjectAppendingMarker("combination", "1 of 2"),
-                          new ObjectAppendingMarker("event_id", HMRC_MATCHING_SUCCESS_RECEIVED));
+                          new ObjectAppendingMarker(EVENT, HMRC_MATCHING_SUCCESS_RECEIVED));
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isNameMatchingAnalysis);
 
     }
@@ -146,7 +146,7 @@ public class HmrcHateoasClientTest {
         LoggingEvent loggingEvent = findLog("Failed to match individual NR123456C");
 
         assertThat(loggingEvent.getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_MATCHING_FAILURE_RECEIVED));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_MATCHING_FAILURE_RECEIVED));
     }
 
     @Test
@@ -165,9 +165,9 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         assertThat(findLog("Match attempt 1 of 2").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_MATCHING_ATTEMPTS));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_MATCHING_ATTEMPTS));
         assertThat(findLog("Match attempt 2 of 2").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_MATCHING_ATTEMPTS));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_MATCHING_ATTEMPTS));
     }
 
     @Test(expected = HttpClientErrorException.class)
@@ -202,7 +202,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         assertThat(findLog("Sending PAYE request to HMRC").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_PAYE_REQUEST_SENT));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_PAYE_REQUEST_SENT));
     }
 
     @Test
@@ -218,7 +218,7 @@ public class HmrcHateoasClientTest {
 
         LoggingEvent loggingEvent = findLog("PAYE response received from HMRC");
         assertThat(loggingEvent.getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_PAYE_RESPONSE_RECEIVED));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_PAYE_RESPONSE_RECEIVED));
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
@@ -234,7 +234,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         assertThat(findLog("Sending Self Assessment self employment request to HMRC").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_SA_REQUEST_SENT));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_SA_REQUEST_SENT));
     }
 
     @Test
@@ -249,7 +249,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         LoggingEvent loggingEvent = findLog("Self Assessment self employment response received from HMRC");
-        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_SA_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker(EVENT, HMRC_SA_RESPONSE_RECEIVED));
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
@@ -265,7 +265,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         assertThat(findLog("Sending Employments request to HMRC").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_REQUEST_SENT));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_REQUEST_SENT));
     }
 
     @Test
@@ -280,7 +280,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         LoggingEvent loggingEvent = findLog("Employments response received from HMRC");
-        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_RESPONSE_RECEIVED));
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
@@ -295,7 +295,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         assertThat(findLog("About to GET individual resource from HMRC at http://something.com/anyurl").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_INDIVIDUAL_REQUEST_SENT));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_INDIVIDUAL_REQUEST_SENT));
     }
 
     @Test
@@ -309,7 +309,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         LoggingEvent loggingEvent = findLog("Individual resource response received");
-        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_INDIVIDUAL_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker(EVENT, HMRC_INDIVIDUAL_RESPONSE_RECEIVED));
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
@@ -324,7 +324,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         assertThat(findLog("About to GET income resource from HMRC at http://something.com/anyurl").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_INCOME_REQUEST_SENT));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_INCOME_REQUEST_SENT));
     }
 
     @Test
@@ -338,7 +338,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         LoggingEvent loggingEvent = findLog("Income resource response received");
-        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_INCOME_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker(EVENT, HMRC_INCOME_RESPONSE_RECEIVED));
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
@@ -353,7 +353,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         assertThat(findLog("About to GET employment resource from HMRC at http://something.com/anyurl").getArgumentArray())
-                .contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_REQUEST_SENT));
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_REQUEST_SENT));
     }
 
     @Test
@@ -367,7 +367,7 @@ public class HmrcHateoasClientTest {
                 .doAppend(logArgumentCaptor.capture());
 
         LoggingEvent loggingEvent = findLog("Employment resource response received");
-        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_RESPONSE_RECEIVED));
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
@@ -376,15 +376,13 @@ public class HmrcHateoasClientTest {
         given(mockHmrcCallWrapper.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class))).willReturn(mockResponse);
 
         client.getSelfAssessmentResource("token", "2010-11", "2011-12", new Link("http://something.com/anyurl"));
-
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("About to get self assessment resource from HMRC at http://something.com/anyurl?fromTaxYear=2010-11&toTaxYear=2011-12") &&
-                            (loggingEvent.getArgumentArray()[1]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_REQUEST_SENT));
-                }));
+        LoggingEvent loggingEvent = findLog("About to get self assessment resource from HMRC at http://something.com/anyurl?fromTaxYear=2010-11&toTaxYear=2011-12");
+        assertThat(loggingEvent.getArgumentArray())
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_SA_REQUEST_SENT));
     }
 
     @Test
@@ -394,14 +392,12 @@ public class HmrcHateoasClientTest {
         client.getSelfAssessmentResource("token", "2010-11", "2011-12", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Self assessment resource response received") &&
-                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_SA_RESPONSE_RECEIVED)) &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
-                }));
+        LoggingEvent loggingEvent = findLog("Self assessment resource response received");
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker(EVENT, HMRC_SA_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
@@ -101,13 +101,11 @@ public class HmrcHateoasClientTest {
         client.getMatchResource(individual, "");
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Match Individual NR123456C via a POST to http://localhost/individuals/matching/") &&
-                            loggingEvent.getArgumentArray()[2].equals(new ObjectAppendingMarker(EVENT, HMRC_MATCHING_REQUEST_SENT));
-                }));
+        assertThat(findLog("Match Individual NR123456C via a POST to http://localhost/individuals/matching/").getArgumentArray())
+                .contains(new ObjectAppendingMarker(EVENT, HMRC_MATCHING_REQUEST_SENT));
     }
 
     @Test
@@ -528,7 +526,7 @@ public class HmrcHateoasClientTest {
                                                                .filter(log -> log.getFormattedMessage().equals(message))
                                                                .findFirst();
         if (!matchedEvent.isPresent()) {
-            fail("No caputred logs with message=" + message);
+            fail("No captured logs with message=" + message);
         }
         return matchedEvent.get();
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.omg.CORBA.portable.ApplicationException;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Link;
@@ -115,15 +114,16 @@ public class HmrcHateoasClientTest {
 
         client.getMatchResource(individual, "");
 
-        then(mockAppender).should(atLeastOnce())
-                          .doAppend(logArgumentCaptor.capture());
+        then(mockAppender)
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-        LoggingEvent loggingEvent = logArgumentCaptor.getValue();
+        LoggingEvent loggingEvent = findLog("Successfully matched individual NR123456C");
 
-        assertThat(loggingEvent.getFormattedMessage()).isEqualTo("Successfully matched individual NR123456C");
         assertThat(loggingEvent.getArgumentArray())
                 .contains(new ObjectAppendingMarker("combination", "1 of 2"),
                           new ObjectAppendingMarker(EVENT, HMRC_MATCHING_SUCCESS_RECEIVED));
+
         assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isNameMatchingAnalysis);
 
     }
@@ -139,8 +139,9 @@ public class HmrcHateoasClientTest {
             // Swallowed as not of interest for this test.
         }
 
-        then(mockAppender).should(atLeastOnce())
-                          .doAppend(logArgumentCaptor.capture());
+        then(mockAppender)
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
         LoggingEvent loggingEvent = findLog("Failed to match individual NR123456C");
 

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
@@ -495,13 +495,11 @@ public class HmrcHateoasClientTest {
 
         then(mockAppender)
                 .should(atLeastOnce())
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Skipped HMRC call due to Invalid Identity: Normalized name contains a blank name") &&
-                            loggingEvent.getLevel().equals(Level.INFO) &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("event_id");
-                }));
+        LoggingEvent loggingEvent = findLog("Skipped HMRC call due to Invalid Identity: Normalized name contains a blank name");
+        assertThat(loggingEvent.getLevel()).isEqualTo(Level.INFO);
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker(EVENT, HMRC_MATCHING_ATTEMPT_SKIPPED));
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcHateoasClientTest.java
@@ -261,13 +261,11 @@ public class HmrcHateoasClientTest {
         client.getEmployments(LocalDate.of(2018, 8, 3), LocalDate.of(2018, 8, 3), "token", new Link("http://foo.com/bar"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Sending Employments request to HMRC") &&
-                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_REQUEST_SENT));
-                }));
+        assertThat(findLog("Sending Employments request to HMRC").getArgumentArray())
+                .contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_REQUEST_SENT));
     }
 
     @Test
@@ -278,14 +276,12 @@ public class HmrcHateoasClientTest {
         client.getEmployments(LocalDate.of(2018, 8, 3), LocalDate.of(2018, 8, 3), "token", new Link("http://foo.com/bar"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Employments response received from HMRC") &&
-                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_RESPONSE_RECEIVED)) &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
-                }));
+        LoggingEvent loggingEvent = findLog("Employments response received from HMRC");
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
     @Test
@@ -295,13 +291,11 @@ public class HmrcHateoasClientTest {
         client.getIndividualResource("token", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("About to GET individual resource from HMRC at http://something.com/anyurl") &&
-                            (loggingEvent.getArgumentArray()[1]).equals(new ObjectAppendingMarker(EVENT, HMRC_INDIVIDUAL_REQUEST_SENT));
-                }));
+        assertThat(findLog("About to GET individual resource from HMRC at http://something.com/anyurl").getArgumentArray())
+                .contains(new ObjectAppendingMarker("event_id", HMRC_INDIVIDUAL_REQUEST_SENT));
     }
 
     @Test
@@ -311,14 +305,12 @@ public class HmrcHateoasClientTest {
         client.getIndividualResource("token", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Individual resource response received") &&
-                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_INDIVIDUAL_RESPONSE_RECEIVED)) &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
-                }));
+        LoggingEvent loggingEvent = findLog("Individual resource response received");
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_INDIVIDUAL_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
     @Test
@@ -328,13 +320,11 @@ public class HmrcHateoasClientTest {
         client.getIncomeResource("token", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("About to GET income resource from HMRC at http://something.com/anyurl") &&
-                            (loggingEvent.getArgumentArray()[1]).equals(new ObjectAppendingMarker(EVENT, HMRC_INCOME_REQUEST_SENT));
-                }));
+        assertThat(findLog("About to GET income resource from HMRC at http://something.com/anyurl").getArgumentArray())
+                .contains(new ObjectAppendingMarker("event_id", HMRC_INCOME_REQUEST_SENT));
     }
 
     @Test
@@ -344,14 +334,12 @@ public class HmrcHateoasClientTest {
         client.getIncomeResource("token", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Income resource response received") &&
-                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_INCOME_RESPONSE_RECEIVED)) &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
-                }));
+        LoggingEvent loggingEvent = findLog("Income resource response received");
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_INCOME_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
     @Test
@@ -361,13 +349,11 @@ public class HmrcHateoasClientTest {
         client.getEmploymentResource("token", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("About to GET employment resource from HMRC at http://something.com/anyurl") &&
-                            (loggingEvent.getArgumentArray()[1]).equals(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_REQUEST_SENT));
-                }));
+        assertThat(findLog("About to GET employment resource from HMRC at http://something.com/anyurl").getArgumentArray())
+                .contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_REQUEST_SENT));
     }
 
     @Test
@@ -377,14 +363,12 @@ public class HmrcHateoasClientTest {
         client.getEmploymentResource("token", new Link("http://something.com/anyurl"));
 
         then(mockAppender)
-                .should()
-                .doAppend(argThat(argument -> {
-                    LoggingEvent loggingEvent = (LoggingEvent) argument;
+                .should(atLeastOnce())
+                .doAppend(logArgumentCaptor.capture());
 
-                    return loggingEvent.getFormattedMessage().equals("Employment resource response received") &&
-                            (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_EMPLOYMENTS_RESPONSE_RECEIVED)) &&
-                            ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("request_duration_ms");
-                }));
+        LoggingEvent loggingEvent = findLog("Employment resource response received");
+        assertThat(loggingEvent.getArgumentArray()).contains(new ObjectAppendingMarker("event_id", HMRC_EMPLOYMENTS_RESPONSE_RECEIVED));
+        assertThat(loggingEvent.getArgumentArray()).anyMatch(this::isRequestDurationLog);
     }
 
     @Test


### PR DESCRIPTION
Refactored the tests in HmrcHateoasClientTest to use a logCaptor rather than an argThat matcher. This is more readible in my opinion and it is definitely easier to debug. 

I have also made sure that any tests that were not asserting against the value of the log event do so now.

I then identified that the HMRC_NAME_MATCHING_UNSUCCESSFUL log is never verified so I added in this missing test case.

All of this work is to make it easier for me to implement EE-15233. As it is only a unit test refactor, I will merge immediately.