### PR TITLE
Ee 15233 flexible name matching bdd

### DIFF
--- a/src/test/java/bdd/steps/NameMatchingSteps.java
+++ b/src/test/java/bdd/steps/NameMatchingSteps.java
@@ -642,10 +642,8 @@ public class NameMatchingSteps {
     }
 
     private boolean metaDataIsSolelyInputNames(List<MetaDataInputName> names, LoggingEvent loggingEvent) {
-        Optional<ObjectAppendingMarker> nameMatchingAnalysisLogArg = Arrays.stream(loggingEvent.getArgumentArray())
-                                                                           .filter(logArg -> loggedFieldEquals(logArg, "name-matching-analysis"))
-                                                                           .map(logArg -> (ObjectAppendingMarker) logArg)
-                                                                           .findFirst();
+        Optional<ObjectAppendingMarker> nameMatchingAnalysisLogArg = getLogArgument(loggingEvent, "name-matching-analysis");
+
         if (!nameMatchingAnalysisLogArg.isPresent()) {
             return false;
         }
@@ -722,11 +720,7 @@ public class NameMatchingSteps {
     }
 
     private CandidateDerivation getCandidateDerivation(LoggingEvent loggingEvent) {
-        ObjectAppendingMarker nameMatchingAnalysisLogArg = Arrays.stream(loggingEvent.getArgumentArray())
-                                                                 .filter(logArg -> loggedFieldEquals(logArg, "name-matching-analysis"))
-                                                                 .map(logArg -> (ObjectAppendingMarker) logArg)
-                                                                 .findFirst()
-                                                                 .orElseThrow(AssertionError::new);
+        ObjectAppendingMarker nameMatchingAnalysisLogArg = getLogArgument(loggingEvent, "name-matching-analysis").orElseThrow(AssertionError::new);
 
         return (CandidateDerivation) ReflectionTestUtils.getField(nameMatchingAnalysisLogArg, "object");
     }
@@ -816,7 +810,7 @@ public class NameMatchingSteps {
     }
 
     private boolean diagnoseWrongNumberOfMatchingAttempts(Integer expected, LoggingEvent loggingEvent) {
-        Optional<ObjectAppendingMarker> combinationLogArgument = getCombinationLogArgument(loggingEvent);
+        Optional<ObjectAppendingMarker> combinationLogArgument = getLogArgument(loggingEvent, "combination");
 
         if (!combinationLogArgument.isPresent()) {
             log.error("Expected: {} but no combination found", expected);
@@ -829,7 +823,7 @@ public class NameMatchingSteps {
     }
 
     private boolean metaDataRecordsMatchingAttempts(Integer combination, LoggingEvent loggingEvent) {
-        Optional<ObjectAppendingMarker> combinationLogArgument = getCombinationLogArgument(loggingEvent);
+        Optional<ObjectAppendingMarker> combinationLogArgument = getLogArgument(loggingEvent, "combination");
 
         if (!combinationLogArgument.isPresent()) {
             return false;
@@ -839,9 +833,9 @@ public class NameMatchingSteps {
         return attemptsString != null && attemptsString.equals(String.format("%d of %d", combination, combination));
     }
 
-    private Optional<ObjectAppendingMarker> getCombinationLogArgument(LoggingEvent loggingEvent) {
+    private Optional<ObjectAppendingMarker> getLogArgument(LoggingEvent loggingEvent, String fieldName) {
         return Arrays.stream(loggingEvent.getArgumentArray())
-                     .filter(logArg -> loggedFieldEquals(logArg, "combination"))
+                     .filter(logArg -> loggedFieldEquals(logArg, fieldName))
                      .map(logArg -> (ObjectAppendingMarker) logArg)
                      .findFirst();
     }

--- a/src/test/java/bdd/steps/NameMatchingSteps.java
+++ b/src/test/java/bdd/steps/NameMatchingSteps.java
@@ -622,6 +622,7 @@ public class NameMatchingSteps {
         return Arrays.stream(loggingEvent.getArgumentArray())
                      .anyMatch(logArg -> loggedFieldEquals(logArg, "name-matching-analysis"));
     }
+
     private boolean metaDataHasExpectedNumberOfInputNames(List<MetaDataInputName> names, LoggingEvent loggingEvent) {
 
         CandidateDerivation candidateDerivation = getCandidateDerivation(loggingEvent);
@@ -815,26 +816,26 @@ public class NameMatchingSteps {
     }
 
     private boolean diagnoseWrongNumberOfMatchingAttempts(Integer expected, LoggingEvent loggingEvent) {
-        Optional<ObjectAppendingMarker> combinationArgument = getCombinationLogArgument(loggingEvent);
+        Optional<ObjectAppendingMarker> combinationLogArgument = getCombinationLogArgument(loggingEvent);
 
-        if (!combinationArgument.isPresent()) {
+        if (!combinationLogArgument.isPresent()) {
             log.error("Expected: {} but no combination found", expected);
             return false;
         }
 
-        String actual = (String) ReflectionTestUtils.getField(combinationArgument.get(), "object");
+        String actual = (String) ReflectionTestUtils.getField(combinationLogArgument.get(), "object");
         log.error("Expected: {} Actual: {}", String.format("%d of %d", expected, expected), actual);
         return false;
     }
 
-    private boolean metaDataRecordsMatchingAttempts(int combination, LoggingEvent loggingEvent) {
-        Optional<ObjectAppendingMarker> combinationArgument = getCombinationLogArgument(loggingEvent);
+    private boolean metaDataRecordsMatchingAttempts(Integer combination, LoggingEvent loggingEvent) {
+        Optional<ObjectAppendingMarker> combinationLogArgument = getCombinationLogArgument(loggingEvent);
 
-        if (!combinationArgument.isPresent()) {
+        if (!combinationLogArgument.isPresent()) {
             return false;
         }
 
-        String attemptsString = (String) ReflectionTestUtils.getField(combinationArgument.get(), "object");
+        String attemptsString = (String) ReflectionTestUtils.getField(combinationLogArgument.get(), "object");
         return attemptsString != null && attemptsString.equals(String.format("%d of %d", combination, combination));
     }
 


### PR DESCRIPTION
Current Name Matching Metadata BDD is dependent on the order that the logged values are passed to the log.info() method in HmrcHateoasClient. I'm going to be modifying these logs so it will help me if the tests are a little more flexible.

To that end I have changed the BDD steps so that rather than looking at a specific index of the log arguments, they will search through them all for the appropriate one to assert against.

As this is only test refactoring I intend to merge into master immediately.