### PR TITLE
Ee 6825 accept test nino smoke test

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/HmrcResource.java
@@ -61,7 +61,9 @@ class HmrcResource {
 
     private Individual individual(String firstName, String lastName, String nino, LocalDate dob, String aliasSurnames) {
         String sanitisedNino = ninoUtils.sanitise(nino);
-        ninoUtils.validate(sanitisedNino);
+        if (!requestHeaderData.isASmokeTest()) {
+            ninoUtils.validate(sanitisedNino);
+        }
         return new Individual(firstName, lastName, sanitisedNino, dob, aliasSurnames);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
@@ -38,6 +38,8 @@ public class RequestHeaderData implements HandlerInterceptor {
 
     static final long EXPECTED_REMAINING_TIME_TO_COMPLETE = 0;
 
+    public static final String SMOKE_TESTS_USER_ID = "smoke-tests";
+
     @Value("${auditing.deployment.name}") private String deploymentName;
     @Value("${auditing.deployment.namespace}") private String deploymentNamespace;
     @Value("${hmrc.access.service.auth}") private String hmrcAccessBasicAuth;
@@ -216,5 +218,9 @@ public class RequestHeaderData implements HandlerInterceptor {
             log.info("Insufficient time to complete the Response - {} ms remaining and expected duration is {}", remainingTime, minTimeToRespond, value(EVENT, HMRC_INSUFFICIENT_TIME_TO_COMPLETE));
             throw new InsufficientTimeException("Insufficient time to complete the Response");
         }
+    }
+
+    public boolean isASmokeTest() {
+        return userId().equals(SMOKE_TESTS_USER_ID);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestHeaderData.java
@@ -220,7 +220,7 @@ public class RequestHeaderData implements HandlerInterceptor {
         }
     }
 
-    public boolean isASmokeTest() {
+    boolean isASmokeTest() {
         return userId().equals(SMOKE_TESTS_USER_ID);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceContractTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceContractTest.java
@@ -15,16 +15,11 @@ import uk.gov.digital.ho.pttg.application.domain.Individual;
 import java.time.LocalDate;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static uk.gov.digital.ho.pttg.api.JsonRequestUtilities.*;

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceContractTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceContractTest.java
@@ -9,15 +9,22 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.digital.ho.pttg.application.domain.IncomeSummary;
 import uk.gov.digital.ho.pttg.application.domain.Individual;
 
 import java.time.LocalDate;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static uk.gov.digital.ho.pttg.api.JsonRequestUtilities.*;
@@ -27,6 +34,8 @@ import static uk.gov.digital.ho.pttg.api.RequestHeaderData.*;
 @SpringBootTest
 @AutoConfigureMockMvc
 public class HmrcResourceContractTest {
+
+    private static final String SMOKE_TEST_NINO = "QQ123456C";
 
     @MockBean
     private IncomeSummaryService incomeSummaryService;
@@ -167,4 +176,30 @@ public class HmrcResourceContractTest {
                 .andExpect(header().string(USER_ID_HEADER, "unknown"));
     }
 
+    @Test
+    public void getHmrcData_smokeTestNino_smokeTest_returnOk() throws Exception {
+        LocalDate anyDateOfBirth = LocalDate.now();
+        Individual anyIndividual = new Individual("any firstName", "any lastName", "any nino", anyDateOfBirth, "any alias surnames");
+        IncomeSummary anyIncomeSummary = new IncomeSummary(emptyList(), emptyList(), emptyList(), anyIndividual);
+
+        when(incomeSummaryService.getIncomeSummary(any(Individual.class), any(LocalDate.class), any(LocalDate.class))).thenReturn(anyIncomeSummary);
+
+        mockMvc.perform(post("/income")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(getRequestAndReplaceValue("nino", SMOKE_TEST_NINO))
+                                .header(USER_ID_HEADER, SMOKE_TESTS_USER_ID)
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getHmrcData_smokeTestNino_notASmokeTest_returnUnprocessableEntity() throws Exception {
+        mockMvc.perform(post("/income")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(getRequestAndReplaceValue("nino", SMOKE_TEST_NINO))
+                                .header(USER_ID_HEADER, "not a smoke-test user")
+                                .accept(MediaType.APPLICATION_JSON))
+               .andExpect(status().isUnprocessableEntity())
+               .andExpect(content().string(containsString("NINO")));
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceTest.java
@@ -25,8 +25,9 @@ import static java.time.Month.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HmrcResourceTest {
@@ -118,5 +119,23 @@ public class HmrcResourceTest {
                             ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[2]).getFieldName().equals("pool_size")
                     ;
         }));
+    }
+
+    @Test
+    public void getHmrcData_notASmokeTest_validateNino() {
+        given(mockRequestHeaderData.isASmokeTest()).willReturn(false);
+
+        hmrcResource.getHmrcData(new IncomeDataRequest(FIRST_NAME, LAST_NAME, NINO, DATE_OF_BIRTH, FROM_DATE, TO_DATE, ALIAS_SURNAMES));
+
+        then(mockNinoUtils).should().validate(NINO);
+    }
+
+    @Test
+    public void getHmrcData_smokeTest_doNotValidateNino() {
+        given(mockRequestHeaderData.isASmokeTest()).willReturn(true);
+
+        hmrcResource.getHmrcData(new IncomeDataRequest(FIRST_NAME, LAST_NAME, NINO, DATE_OF_BIRTH, FROM_DATE, TO_DATE, ALIAS_SURNAMES));
+
+        then(mockNinoUtils).should(never()).validate(NINO);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/RequestHeaderDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/RequestHeaderDataTest.java
@@ -31,8 +31,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static uk.gov.digital.ho.pttg.Failable.when_ExceptionThrownBy;
-import static uk.gov.digital.ho.pttg.api.RequestHeaderData.EXPECTED_REMAINING_TIME_TO_COMPLETE;
-import static uk.gov.digital.ho.pttg.api.RequestHeaderData.MAX_DURATION_MS_HEADER;
+import static uk.gov.digital.ho.pttg.api.RequestHeaderData.*;
 import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_INSUFFICIENT_TIME_TO_COMPLETE;
 import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_SERVICE_GENERATED_CORRELATION_ID;
 
@@ -242,6 +241,24 @@ public class RequestHeaderDataTest {
                         "Insufficient time to complete the Response - -1 ms remaining and expected duration is 0",
                         2,
                         HMRC_INSUFFICIENT_TIME_TO_COMPLETE)));
+    }
+
+    @Test
+    public void isASmokeTest_smokeTestUser_returnTrue() {
+        given(mockHttpServletRequest.getHeader(USER_ID_HEADER)).willReturn("smoke-tests");
+
+        given_requestDataPrehandleCalled();
+
+        assertThat(requestData.isASmokeTest()).isTrue();
+    }
+
+    @Test
+    public void isASmokeTest_notSmokeTestUser_returnFalse() {
+        given(mockHttpServletRequest.getHeader(USER_ID_HEADER)).willReturn("not a smoke test user");
+
+        given_requestDataPrehandleCalled();
+
+        assertThat(requestData.isASmokeTest()).isFalse();
     }
 
     private void given_requestDataPrehandleCalled() {


### PR DESCRIPTION
Making it so that Nino validation is skipped if the user-id is the one used by the smoke tests.

I intend to merge once approved.