### PR TITLE
Ee 6825 add audit trace

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
@@ -1,11 +1,16 @@
 package uk.gov.digital.ho.pttg.api;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ComponentTraceHeaderData implements HandlerInterceptor {
 
@@ -20,11 +25,46 @@ public class ComponentTraceHeaderData implements HandlerInterceptor {
         return true;
     }
 
+    public void updateComponentTrace(ResponseEntity responseEntity) {
+        List<String> componentTraceHeaders = responseEntity.getHeaders().get(COMPONENT_TRACE_HEADER);
+        if (componentTraceHeaders == null || componentTraceHeaders.isEmpty()) {
+            return;
+        }
+
+        setComponentTrace(componentTraceHeaders);
+    }
+
+    public void updateComponentTrace(HttpStatusCodeException httpException) {
+        if (httpException.getResponseHeaders() == null) {
+            return;
+        }
+
+        List<String> componentTraceHeaders = httpException.getResponseHeaders().get(COMPONENT_TRACE_HEADER);
+        setComponentTrace(componentTraceHeaders);
+    }
+
     public void addComponentTraceHeader(HttpHeaders headers) {
         headers.add(COMPONENT_TRACE_HEADER, componentTrace());
     }
 
     String componentTrace() {
         return MDC.get(COMPONENT_TRACE_HEADER);
+    }
+
+    private void setComponentTrace(List<String> componentTraceHeaders) {
+        if (componentTraceHeaders == null) {
+            return;
+        }
+
+        List<String> components = removeEmptyHeaders(componentTraceHeaders);
+        if (!components.isEmpty()) {
+            MDC.put(COMPONENT_TRACE_HEADER, String.join(",", components));
+        }
+    }
+
+    private List<String> removeEmptyHeaders(List<String> componentTraceHeaders) {
+        return componentTraceHeaders.stream()
+                                    .filter(StringUtils::isNotEmpty)
+                                    .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
@@ -35,11 +35,12 @@ public class ComponentTraceHeaderData implements HandlerInterceptor {
     }
 
     public void updateComponentTrace(HttpStatusCodeException httpException) {
-        if (httpException.getResponseHeaders() == null) {
+        HttpHeaders headers = httpException.getResponseHeaders();
+        if (headers == null) {
             return;
         }
 
-        List<String> componentTraceHeaders = httpException.getResponseHeaders().get(COMPONENT_TRACE_HEADER);
+        List<String> componentTraceHeaders = headers.get(COMPONENT_TRACE_HEADER);
         setComponentTrace(componentTraceHeaders);
     }
 

--- a/src/main/java/uk/gov/digital/ho/pttg/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/audit/AuditClient.java
@@ -43,7 +43,8 @@ public class AuditClient {
     public AuditClient(Clock clock,
                        @Qualifier("auditRestTemplate") RestTemplate restTemplate,
                        RequestHeaderData requestHeaderData,
-                       ComponentTraceHeaderData componentTraceHeaderData, @Value("${pttg.audit.endpoint}") String auditEndpoint,
+                       ComponentTraceHeaderData componentTraceHeaderData,
+                       @Value("${pttg.audit.endpoint}") String auditEndpoint,
                        ObjectMapper mapper,
                        @Value("#{${audit.service.retry.attempts}}") int maxCallAttempts,
                        @Value("#{${audit.service.retry.delay}}") int retryDelay) {

--- a/src/main/java/uk/gov/digital/ho/pttg/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/audit/AuditClient.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.pttg.api.ComponentTraceHeaderData;
@@ -25,7 +24,8 @@ import static net.logstash.logback.argument.StructuredArguments.value;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static uk.gov.digital.ho.pttg.application.LogEvent.*;
+import static uk.gov.digital.ho.pttg.application.LogEvent.EVENT;
+import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_AUDIT_FAILURE;
 
 @Component
 @Slf4j

--- a/src/test/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderDataTest.java
@@ -7,9 +7,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;
@@ -66,5 +71,141 @@ public class ComponentTraceHeaderDataTest {
         componentTraceHeaderData.addComponentTraceHeader(mockHeaders);
 
         then(mockHeaders).should().add(COMPONENT_TRACE_HEADER, expectedComponentTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_responseEntityNoTraceHeader_doNotUpdate() {
+        String expectedComponentTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedComponentTrace);
+
+        ResponseEntity responseWithoutTraceHeader = ResponseEntity.ok("");
+        componentTraceHeaderData.updateComponentTrace(responseWithoutTraceHeader);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedComponentTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_responseEntityNullTraceHeader_doNotUpdate() {
+        String expectedComponentTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedComponentTrace);
+
+        ResponseEntity responseWithoutNullHeader = new ResponseEntity(componentTraceHeader(null), HttpStatus.OK);
+        componentTraceHeaderData.updateComponentTrace(responseWithoutNullHeader);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedComponentTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_responseEntityEmptyTraceHeader_doNotUpdate() {
+        String expectedComponentTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedComponentTrace);
+
+        ResponseEntity responseWithoutNullHeader = new ResponseEntity(componentTraceHeader(""), HttpStatus.OK);
+        componentTraceHeaderData.updateComponentTrace(responseWithoutNullHeader);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedComponentTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_responseEntityTraceHeader_update() {
+        String initialTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, initialTrace);
+
+        String expectedTrace = "pttg-ip-hmrc,pttg-ip-audit";
+        ResponseEntity responseWithTraceHeader = new ResponseEntity(componentTraceHeader(expectedTrace), HttpStatus.OK);
+        componentTraceHeaderData.updateComponentTrace(responseWithTraceHeader);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_multipleResponseEntityCalls_lastWins() {
+        String firstTrace = "pttg-ip-hmrc";
+        ResponseEntity firstResponse = new ResponseEntity(componentTraceHeader(firstTrace), HttpStatus.OK);
+        componentTraceHeaderData.updateComponentTrace(firstResponse);
+
+        String expectedTrace = "pttg-ip-hmrc,pttg-ip-audit";
+        ResponseEntity winningResponse = new ResponseEntity(componentTraceHeader(expectedTrace), HttpStatus.OK);
+        componentTraceHeaderData.updateComponentTrace(winningResponse);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_exceptionNoHeaders_doNotUpdate() {
+        String expectedTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedTrace);
+
+        HttpStatusCodeException httpException = new HttpClientErrorException(HttpStatus.BAD_REQUEST);
+        componentTraceHeaderData.updateComponentTrace(httpException);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_exceptionNullTraceHeader_doNotUpdate() {
+        String expectedTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedTrace);
+
+        HttpStatusCodeException httpExceptionWithNullTrace = new HttpClientErrorException(HttpStatus.BAD_REQUEST, "any text", componentTraceHeader(null), null, null);
+        componentTraceHeaderData.updateComponentTrace(httpExceptionWithNullTrace);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_exceptionEmptyTraceHeader_doNotUpdate() {
+        String expectedTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedTrace);
+
+        HttpStatusCodeException httpExceptionWithEmptyTrace = new HttpClientErrorException(HttpStatus.BAD_REQUEST, "any text", componentTraceHeader(""), null, null);
+        componentTraceHeaderData.updateComponentTrace(httpExceptionWithEmptyTrace);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_exceptionOtherHeaders_doNotUpdate() {
+        String expectedTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedTrace);
+
+        HttpHeaders otherHeaders = new HttpHeaders();
+        otherHeaders.put("some other header", Collections.singletonList("some other value"));
+        HttpStatusCodeException httpExceptionWithEmptyTrace = new HttpClientErrorException(HttpStatus.BAD_REQUEST, "any text", otherHeaders, null, null);
+        componentTraceHeaderData.updateComponentTrace(httpExceptionWithEmptyTrace);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_exceptionWithTrace_update() {
+        String initialTrace = "pttg-ip-hmrc";
+        MDC.put(COMPONENT_TRACE_HEADER, initialTrace);
+
+        String expectedTrace = "pttg-ip-hmrc,pttg-ip-api";
+        HttpStatusCodeException httpExceptionWithTrace = new HttpClientErrorException(HttpStatus.BAD_REQUEST, "any text", componentTraceHeader(expectedTrace), null, null);
+        componentTraceHeaderData.updateComponentTrace(httpExceptionWithTrace);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    @Test
+    public void updateComponentTrace_multipleExceptionsWithTrace_lastWins() {
+        String initialTrace = "pttg-ip-hmrc";
+        HttpStatusCodeException initialException = new HttpClientErrorException(HttpStatus.BAD_REQUEST, "any text", componentTraceHeader(initialTrace), null, null);
+        componentTraceHeaderData.updateComponentTrace(initialException);
+
+
+        String expectedTrace = "pttg-ip-hmrc,pttg-ip-api";
+        HttpStatusCodeException winningException = new HttpClientErrorException(HttpStatus.BAD_REQUEST, "any text", componentTraceHeader(expectedTrace), null, null);
+        componentTraceHeaderData.updateComponentTrace(winningException);
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
+    }
+
+    private HttpHeaders componentTraceHeader(String components) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(COMPONENT_TRACE_HEADER, components);
+        return headers;
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/audit/AuditClientTest.java
@@ -17,12 +17,12 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.*;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.pttg.api.ComponentTraceHeaderData;
 import uk.gov.digital.ho.pttg.api.RequestHeaderData;
 
 import java.time.Clock;
@@ -33,6 +33,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -46,6 +47,7 @@ public class AuditClientTest {
     private static final String LOG_TEST_APPENDER = "tester";
 
     @Mock private RequestHeaderData mockRequestHeaderData;
+    @Mock private ComponentTraceHeaderData mockComponentTraceHeaderData;
     @Mock private RestTemplate mockRestTemplate;
     @Mock private AuditIndividualData mockAuditableData;
     @Mock private Appender<ILoggingEvent> mockAppender;
@@ -58,8 +60,8 @@ public class AuditClientTest {
     @Before
     public void setup() {
         final Clock clock = Clock.fixed(Instant.now(), ZoneId.of("Europe/London"));
-        client = new AuditClient(clock, mockRestTemplate, mockRequestHeaderData, "endpoint", mockMapper,
-                MAX_RETRY_ATTEMPTS, RETRY_DELAY);
+        client = new AuditClient(clock, mockRestTemplate, mockRequestHeaderData, mockComponentTraceHeaderData, "endpoint", mockMapper,
+                                 MAX_RETRY_ATTEMPTS, RETRY_DELAY);
 
         mockAppender.setName(LOG_TEST_APPENDER);
         Logger logger = (Logger) LoggerFactory.getLogger(AuditClient.class);
@@ -161,4 +163,36 @@ public class AuditClientTest {
         assertThat(headers.get(RequestHeaderData.USER_ID_HEADER).get(0)).isEqualTo("some user id");
     }
 
+    @Test
+    public void add_successResponse_updateComponentTrace() {
+        ResponseEntity<Void> someResponse = new ResponseEntity<>(HttpStatus.OK);
+        given(mockRestTemplate.exchange(eq("endpoint"), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+                .willReturn(someResponse);
+
+        client.add(HMRC_INCOME_REQUEST, UUID.randomUUID(), null);
+
+        then(mockComponentTraceHeaderData).should().updateComponentTrace(someResponse);
+    }
+
+    @Test
+    public void add_httpException_updateComponentTrace() {
+        HttpStatusCodeException someHttpException = new HttpClientErrorException(HttpStatus.BAD_REQUEST);
+        given(mockRestTemplate.exchange(eq("endpoint"), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+                .willThrow(someHttpException);
+
+        client.add(HMRC_INCOME_REQUEST, UUID.randomUUID(), null);
+
+        then(mockComponentTraceHeaderData).should().updateComponentTrace(someHttpException);
+    }
+
+    @Test
+    public void add_otherException_doNotUpdateComponentTrace() {
+        Exception anyException = new NullPointerException();
+        given(mockRestTemplate.exchange(eq("endpoint"), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+                .willThrow(anyException);
+
+        client.add(HMRC_INCOME_REQUEST, UUID.randomUUID(), null);
+
+        then(mockComponentTraceHeaderData).shouldHaveZeroInteractions();
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/audit/AuditClientTest.java
@@ -60,8 +60,8 @@ public class AuditClientTest {
     @Before
     public void setup() {
         final Clock clock = Clock.fixed(Instant.now(), ZoneId.of("Europe/London"));
-        client = new AuditClient(clock, mockRestTemplate, mockRequestHeaderData, mockComponentTraceHeaderData, "endpoint", mockMapper,
-                                 MAX_RETRY_ATTEMPTS, RETRY_DELAY);
+        client = new AuditClient(clock, mockRestTemplate, mockRequestHeaderData, mockComponentTraceHeaderData,
+                                 "endpoint", mockMapper, MAX_RETRY_ATTEMPTS, RETRY_DELAY);
 
         mockAppender.setName(LOG_TEST_APPENDER);
         Logger logger = (Logger) LoggerFactory.getLogger(AuditClient.class);


### PR DESCRIPTION
When hmrc-service calls audit-service, update the component-trace header with the one in the response from audit-service. I intend to merge to master once approved as nothing observable to IPS should have changed.