### PR TITLE
Ee 6825 hmrc trace

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
@@ -44,6 +44,11 @@ public class ComponentTraceHeaderData implements HandlerInterceptor {
         setComponentTrace(componentTraceHeaders);
     }
 
+    public void appendComponentToTrace(String component) {
+        String newTrace = String.format("%s,%s", componentTrace(), component);
+        MDC.put(COMPONENT_TRACE_HEADER, newTrace);
+    }
+
     public void addComponentTraceHeader(HttpHeaders headers) {
         headers.add(COMPONENT_TRACE_HEADER, componentTrace());
     }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapper.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapper.java
@@ -37,11 +37,14 @@ public class HmrcCallWrapper {
     @AbortIfBeyondMaxResponseDuration
     public <T> ResponseEntity<Resource<T>> exchange(URI uri, HttpMethod httpMethod, HttpEntity httpEntity, ParameterizedTypeReference<Resource<T>> reference) {
         try {
-            return restTemplate.exchange(uri, httpMethod, httpEntity, reference);
+            ResponseEntity<Resource<T>> response = restTemplate.exchange(uri, httpMethod, httpEntity, reference);
+            addHmrcToComponentTrace();
+            return response;
         } catch (HttpServerErrorException e) {
             log.info("Received {} - {}", e.getStatusCode(), e.getStatusText());
             throw e;
         } catch (HttpClientErrorException e) {
+            addHmrcToComponentTrace();
             throw handleClientErrorExceptions(e);
         }
     }
@@ -86,4 +89,7 @@ public class HmrcCallWrapper {
         return exception.getResponseBodyAsString().contains("MATCHING_FAILED");
     }
 
+    private void addHmrcToComponentTrace() {
+        componentTraceHeaderData.appendComponentToTrace("HMRC");
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapper.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapper.java
@@ -52,11 +52,14 @@ public class HmrcCallWrapper {
     @AbortIfBeyondMaxResponseDuration
     <T> Resource<T> followTraverson(String link, String accessToken, ParameterizedTypeReference<Resource<T>> reference) {
         try {
-            return traversonFollower.followTraverson(link, accessToken, restTemplate, reference);
+            Resource<T> resource = traversonFollower.followTraverson(link, accessToken, restTemplate, reference);
+            addHmrcToComponentTrace();
+            return resource;
         } catch (HttpServerErrorException e) {
             log.info("Received {} - {}", e.getStatusCode(), e.getStatusText());
             throw e;
         } catch (HttpClientErrorException ex) {
+            addHmrcToComponentTrace();
             throw handleClientErrorExceptions(ex);
         }
     }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapper.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapper.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.pttg.api.ComponentTraceHeaderData;
 import uk.gov.digital.ho.pttg.application.util.TraversonFollower;
 
 import java.net.URI;
@@ -25,10 +26,12 @@ public class HmrcCallWrapper {
 
     private RestTemplate restTemplate;
     private TraversonFollower traversonFollower;
+    private ComponentTraceHeaderData componentTraceHeaderData;
 
-    public HmrcCallWrapper(@Qualifier("hmrcApiRestTemplate") RestTemplate restTemplate, TraversonFollower traversonFollower) {
+    public HmrcCallWrapper(@Qualifier("hmrcApiRestTemplate") RestTemplate restTemplate, TraversonFollower traversonFollower, ComponentTraceHeaderData componentTraceHeaderData) {
         this.restTemplate = restTemplate;
         this.traversonFollower = traversonFollower;
+        this.componentTraceHeaderData = componentTraceHeaderData;
     }
 
     @AbortIfBeyondMaxResponseDuration

--- a/src/test/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderDataTest.java
@@ -203,6 +203,15 @@ public class ComponentTraceHeaderDataTest {
         assertThat(componentTraceHeaderData.componentTrace()).isEqualTo(expectedTrace);
     }
 
+    @Test
+    public void appendComponentToTrace_someComponent_append() {
+        MDC.put(COMPONENT_TRACE_HEADER, "pttg-ip-api,pttg-ip-hmrc");
+
+        componentTraceHeaderData.appendComponentToTrace("HMRC");
+
+        assertThat(componentTraceHeaderData.componentTrace()).isEqualTo("pttg-ip-api,pttg-ip-hmrc,HMRC");
+    }
+
     private HttpHeaders componentTraceHeader(String components) {
         HttpHeaders headers = new HttpHeaders();
         headers.add(COMPONENT_TRACE_HEADER, components);

--- a/src/test/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapperTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/HmrcCallWrapperTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.pttg.api.ComponentTraceHeaderData;
 import uk.gov.digital.ho.pttg.application.ApplicationExceptions.HmrcNotFoundException;
 import uk.gov.digital.ho.pttg.application.ApplicationExceptions.HmrcUnauthorisedException;
 import uk.gov.digital.ho.pttg.application.ApplicationExceptions.ProxyForbiddenException;
@@ -31,6 +32,11 @@ import static uk.gov.digital.ho.pttg.application.ApplicationExceptions.HmrcOverR
 @RunWith(MockitoJUnitRunner.class)
 public class HmrcCallWrapperTest {
 
+    private static final HttpMethod ANY_HTTP_METHOD = POST;
+    private static final HttpEntity<String> ANY_ENTITY = new HttpEntity<>("some-body");
+    private static final ParameterizedTypeReference<Resource<String>> ANY_REFERENCE = new ParameterizedTypeReference<Resource<String>>() {};
+    private static final URI ANY_URI = URI.create("any-uri");
+
     @InjectMocks
     private HmrcCallWrapper hmrcCallWrapper;
 
@@ -38,6 +44,8 @@ public class HmrcCallWrapperTest {
     private RestTemplate mockRestTemplate;
     @Mock
     private TraversonFollower mockTraversonFollower;
+    @Mock
+    private ComponentTraceHeaderData mockComponentTraceHeaderData;
 
     @Test
     public void shouldThrowCustomExceptionForHttpForbidden() {
@@ -45,8 +53,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(FORBIDDEN));
 
         assertThatExceptionOfType(ProxyForbiddenException.class)
-                .isThrownBy(() -> hmrcCallWrapper.exchange(new URI("some-uri"), POST, new HttpEntity("some-body"), new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.exchange(ANY_URI, ANY_HTTP_METHOD, ANY_ENTITY, ANY_REFERENCE));
     }
 
     @Test
@@ -55,8 +62,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(UNAUTHORIZED));
 
         assertThatExceptionOfType(HmrcUnauthorisedException.class)
-                .isThrownBy(() -> hmrcCallWrapper.exchange(new URI("some-uri"), POST, new HttpEntity("some-body"), new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.exchange(ANY_URI, ANY_HTTP_METHOD, ANY_ENTITY, ANY_REFERENCE));
     }
 
     @Test
@@ -67,8 +73,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(FORBIDDEN, "", responseBody, UTF_8));
 
         assertThatExceptionOfType(HmrcNotFoundException.class)
-                .isThrownBy(() -> hmrcCallWrapper.exchange(new URI("some-uri"), POST, new HttpEntity("some-body"), new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.exchange(ANY_URI, ANY_HTTP_METHOD, ANY_ENTITY, ANY_REFERENCE));
     }
 
     @Test
@@ -77,8 +82,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS));
 
         assertThatExceptionOfType(HmrcOverRateLimitException.class)
-                .isThrownBy(() -> hmrcCallWrapper.exchange(new URI("some-uri"), POST, new HttpEntity("some-body"), new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.exchange(ANY_URI, ANY_HTTP_METHOD, ANY_ENTITY, ANY_REFERENCE));
     }
 
     @Test
@@ -87,8 +91,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new NullPointerException());
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> hmrcCallWrapper.exchange(new URI("some-uri"), POST, new HttpEntity("some-body"), new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.exchange(ANY_URI, ANY_HTTP_METHOD, ANY_ENTITY, ANY_REFERENCE));
     }
 
     @Test
@@ -97,8 +100,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(FORBIDDEN));
 
         assertThatExceptionOfType(ProxyForbiddenException.class)
-                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", ANY_REFERENCE));
     }
 
     @Test
@@ -107,8 +109,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(UNAUTHORIZED));
 
         assertThatExceptionOfType(HmrcUnauthorisedException.class)
-                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", ANY_REFERENCE));
     }
 
     @Test
@@ -118,8 +119,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(FORBIDDEN, "", responseBody, UTF_8));
 
         assertThatExceptionOfType(HmrcNotFoundException.class)
-                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", ANY_REFERENCE));
     }
 
     @Test
@@ -128,8 +128,7 @@ public class HmrcCallWrapperTest {
                 .willThrow(new HttpClientErrorException(TOO_MANY_REQUESTS));
 
         assertThatExceptionOfType(HmrcOverRateLimitException.class)
-                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", ANY_REFERENCE));
     }
 
     @Test
@@ -138,8 +137,6 @@ public class HmrcCallWrapperTest {
                 .willThrow(new NullPointerException());
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", new ParameterizedTypeReference<Resource<String>>() {
-                }));
+                .isThrownBy(() -> hmrcCallWrapper.followTraverson("some-link", "some-access-token", ANY_REFERENCE));
     }
-
 }


### PR DESCRIPTION
Making it so that whenever we call HMRC and get either a successful response or a client error, "HMRC" is added to the x-component-trace header.

The two main methods in HmrcCallWrapper, exchange and followTraverson are virtually identical so I have factored out the exception handling etc. into a new method "handleExceptions" which _wraps_ the actual HMRC call. I'm quite keen on passing a function into another in this manner (looks almost like Python!) but I'm happy to be talked out of it if it's a step to far!

There's a tiny bit of tidying in HmrcCallWrapperTest, just using constants called ANY_X instead of inline values for tests where the values don't matter.

I intend to merge once approved.