### PR TITLE
EE-6825 Making the hmrc-service send the x-component-trace header to the audit service when it calls it.

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/ComponentTraceHeaderData.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 public class ComponentTraceHeaderData implements HandlerInterceptor {
 
-    static final String COMPONENT_TRACE_HEADER = "x-component-trace";
+    public static final String COMPONENT_TRACE_HEADER = "x-component-trace";
     private static final String COMPONENT_NAME = "pttg-ip-hmrc";
 
     @Override
@@ -53,7 +53,7 @@ public class ComponentTraceHeaderData implements HandlerInterceptor {
         headers.add(COMPONENT_TRACE_HEADER, componentTrace());
     }
 
-    String componentTrace() {
+    public String componentTrace() {
         return MDC.get(COMPONENT_TRACE_HEADER);
     }
 

--- a/src/main/java/uk/gov/digital/ho/pttg/audit/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/audit/AuditClient.java
@@ -115,6 +115,7 @@ public class AuditClient {
         headers.add(RequestHeaderData.SESSION_ID_HEADER, requestHeaderData.sessionId());
         headers.add(RequestHeaderData.CORRELATION_ID_HEADER, requestHeaderData.correlationId());
         headers.add(RequestHeaderData.USER_ID_HEADER, requestHeaderData.userId());
+        headers.add(ComponentTraceHeaderData.COMPONENT_TRACE_HEADER, componentTraceHeaderData.componentTrace());
 
         return headers;
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HmrcResourceIntegrationTest.java
@@ -46,8 +46,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.client.ExpectedCount.times;
 import static org.springframework.test.web.client.MockRestServiceServer.MockRestServiceServerBuilder;
 import static org.springframework.test.web.client.MockRestServiceServer.bindTo;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 @RunWith(SpringRunner.class)
@@ -613,10 +612,12 @@ public class HmrcResourceIntegrationTest {
         auditHeadersWithTrace.put("x-component-trace", Arrays.asList("pttg-ip-hmrc", "pttg-ip-audit"));
         auditMockService.expect(requestTo(containsString("/audit")))
                         .andExpect(method(POST))
+                        .andExpect(header("x-component-trace", containsString("pttg-ip-hmrc")))
                         .andRespond(withSuccess().headers(auditHeadersWithTrace));
         ResponseEntity<String> responseEntity = performHmrcRequest();
 
         assertThat(getTraceComponents(responseEntity)).contains("pttg-ip-hmrc", "pttg-ip-audit");
+        auditMockService.verify();
     }
 
     @Test
@@ -626,6 +627,7 @@ public class HmrcResourceIntegrationTest {
         ResponseEntity<String> responseEntity = performHmrcRequest();
 
         assertThat(getTraceComponents(responseEntity)).contains("HMRC");
+        hmrcApiMockService.verify();
     }
 
     private void buildAndExpectSuccessfulTraversal() throws IOException {

--- a/src/test/java/uk/gov/digital/ho/pttg/audit/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/audit/AuditClientTest.java
@@ -31,6 +31,7 @@ import java.time.ZoneId;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -151,6 +152,8 @@ public class AuditClientTest {
         when(mockRequestHeaderData.sessionId()).thenReturn("some session id");
         when(mockRequestHeaderData.correlationId()).thenReturn("some correlation id");
         when(mockRequestHeaderData.userId()).thenReturn("some user id");
+        String someComponentTrace = "pttg-ip-api,pttg-ip-hmrc";
+        when(mockComponentTraceHeaderData.componentTrace()).thenReturn(someComponentTrace);
         client.add(HMRC_INCOME_REQUEST, UUID.randomUUID(), null);
 
         verify(mockRestTemplate).exchange(eq("endpoint"), eq(POST), captorHttpEntity.capture(), eq(Void.class));
@@ -161,6 +164,7 @@ public class AuditClientTest {
         assertThat(headers.get(RequestHeaderData.SESSION_ID_HEADER).get(0)).isEqualTo("some session id");
         assertThat(headers.get(RequestHeaderData.CORRELATION_ID_HEADER).get(0)).isEqualTo("some correlation id");
         assertThat(headers.get(RequestHeaderData.USER_ID_HEADER).get(0)).isEqualTo("some user id");
+        assertThat(headers.get(ComponentTraceHeaderData.COMPONENT_TRACE_HEADER).get(0)).isEqualTo(someComponentTrace);
     }
 
     @Test
@@ -193,6 +197,7 @@ public class AuditClientTest {
 
         client.add(HMRC_INCOME_REQUEST, UUID.randomUUID(), null);
 
-        then(mockComponentTraceHeaderData).shouldHaveZeroInteractions();
+        then(mockComponentTraceHeaderData).should(never()).updateComponentTrace(any(ResponseEntity.class));
+        then(mockComponentTraceHeaderData).should(never()).updateComponentTrace(any(HttpStatusCodeException.class));
     }
 }


### PR DESCRIPTION
I missed this out when implementing the x-component-trace headers between components. As this is just a new header being sent between hmrc-service and audit-service I intend to merge once approved unless anybody objects.